### PR TITLE
chore: Move ILogger to LoggerInterface

### DIFF
--- a/.github/workflows/appstore-build-publish.yml
+++ b/.github/workflows/appstore-build-publish.yml
@@ -10,7 +10,7 @@ on:
     types: [published]
 
 env:
-  PHP_VERSION: 8.0
+  PHP_VERSION: 8.2
 
 jobs:
   build_and_publish:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -9,7 +9,7 @@ jobs:
       runs-on: ubuntu-latest
       strategy:
           matrix:
-              ocp-version: [ 'dev-master', 'dev-stable29', 'dev-stable28' ]
+              ocp-version: [ 'dev-master', 'dev-stable30', 'dev-stable29', 'dev-stable28' ]
       name: Nextcloud ${{ matrix.ocp-version }}
       steps:
           - name: Checkout

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -9,7 +9,7 @@ jobs:
       runs-on: ubuntu-latest
       strategy:
           matrix:
-              ocp-version: [ 'dev-master', 'dev-stable28', 'dev-stable27', 'dev-stable26', 'dev-stable25', 'dev-stable24' ]
+              ocp-version: [ 'dev-master', 'dev-stable29', 'dev-stable28' ]
       name: Nextcloud ${{ matrix.ocp-version }}
       steps:
           - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,14 +12,10 @@ jobs:
         php-versions: ['8.2']
         nextcloud-versions: ['master']
         include:
-          - php-versions: 8.0
-            nextcloud-versions: stable25
           - php-versions: 8.2
-            nextcloud-versions: stable26
-          - php-versions: 8.2
-            nextcloud-versions: stable27
-          - php-versions: 8.3
             nextcloud-versions: stable28
+          - php-versions: 8.3
+            nextcloud-versions: stable29
     name: Nextcloud ${{ matrix.nextcloud-versions }} php${{ matrix.php-versions }} unit tests
     steps:
     - name: Set up php${{ matrix.php-versions }}
@@ -57,20 +53,11 @@ jobs:
               nextcloud-versions: ['master']
               db: ['sqlite']
               include:
-                - php-versions: 8.0
-                  nextcloud-versions: stable24
-                  db: 'sqlite'
-                - php-versions: 8.1
-                  nextcloud-versions: stable25
-                  db: 'sqlite'
                 - php-versions: 8.2
-                  nextcloud-versions: stable26
-                  db: 'sqlite'
-                - php-versions: 8.2
-                  nextcloud-versions: stable27
+                  nextcloud-versions: stable28
                   db: 'sqlite'
                 - php-versions: 8.3
-                  nextcloud-versions: stable28
+                  nextcloud-versions: stable29
                   db: 'sqlite'
       name: php${{ matrix.php-versions }}-${{ matrix.db }} integration tests
       steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
       runs-on: ubuntu-latest
       strategy:
           matrix:
-              php-versions: ['8.0']
+              php-versions: ['8.2']
               nextcloud-versions: ['master']
               db: ['sqlite']
               include:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,8 @@ jobs:
             nextcloud-versions: stable28
           - php-versions: 8.3
             nextcloud-versions: stable29
+          - php-versions: 8.3
+            nextcloud-versions: stable30
     name: Nextcloud ${{ matrix.nextcloud-versions }} php${{ matrix.php-versions }} unit tests
     steps:
     - name: Set up php${{ matrix.php-versions }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# [8.11.0](https://github.com/ChristophWurst/nextcloud_sentry/compare/v8.10.1...v8.11.0) (2024-08-29)
+
+
+### Features
+
+* **environment:** Add support for environment config parameter ([d9fc314](https://github.com/ChristophWurst/nextcloud_sentry/commit/d9fc3141cac8112ce84e7d23ca99d15fb4643256))
+
+
+
 ## [8.10.1](https://github.com/ChristophWurst/nextcloud_sentry/compare/v8.10.0...v8.10.1) (2024-07-18)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [8.12.1](https://github.com/ChristophWurst/nextcloud_sentry/compare/v8.12.0...v8.12.1) (2024-10-28)
+
+
+### Bug Fixes
+
+* **deps:** update dependency @sentry/browser to ^7.119.2 ([#691](https://github.com/ChristophWurst/nextcloud_sentry/issues/691)) ([d3b2dec](https://github.com/ChristophWurst/nextcloud_sentry/commit/d3b2dec29a8bd48d38b6ff1f388452b472eda196))
+
+
+
 # [8.12.0](https://github.com/ChristophWurst/nextcloud_sentry/compare/v8.11.0...v8.12.0) (2024-10-25)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# [8.10.0](https://github.com/ChristophWurst/nextcloud_sentry/compare/v8.9.9...v8.10.0) (2024-07-17)
+
+
+### Bug Fixes
+
+* **deps:** update dependency @nextcloud/initial-state to ^2.2.0 ([5429a22](https://github.com/ChristophWurst/nextcloud_sentry/commit/5429a227e03c5214e21fc75567ceeeca70171566))
+* **deps:** update dependency @sentry/browser to ^7.118.0 ([d357504](https://github.com/ChristophWurst/nextcloud_sentry/commit/d3575042ff4aa0615d5189d6df7199347a058032))
+
+
+### Features
+
+* **deps:** Support Nextcloud 30, drop 24-27 ([ae22cbe](https://github.com/ChristophWurst/nextcloud_sentry/commit/ae22cbe68b1cd59d51e19c9ee293b7e0fac4be45))
+
+
+
 ## [8.9.9](https://github.com/ChristophWurst/nextcloud_sentry/compare/v8.9.8...v8.9.9) (2024-03-25)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+# [8.12.0](https://github.com/ChristophWurst/nextcloud_sentry/compare/v8.11.0...v8.12.0) (2024-10-25)
+
+
+### Bug Fixes
+
+* **deps:** update dependency @nextcloud/auth to ^2.4.0 ([8afa3b6](https://github.com/ChristophWurst/nextcloud_sentry/commit/8afa3b63b26e0056b36d150f190100bfe70908ad))
+* **deps:** update dependency @nextcloud/logger to v3 ([91d076b](https://github.com/ChristophWurst/nextcloud_sentry/commit/91d076b73916e517a7673d74526e8f5504162453))
+* **deps:** update dependency @sentry/browser to v7.119.1 [security] ([#687](https://github.com/ChristophWurst/nextcloud_sentry/issues/687)) ([5770142](https://github.com/ChristophWurst/nextcloud_sentry/commit/5770142f03e075cf745e059b87965a409b7df3d8))
+* **deps:** update dependency nyholm/psr7 to ^1.8.2 ([#686](https://github.com/ChristophWurst/nextcloud_sentry/issues/686)) ([bf3cec4](https://github.com/ChristophWurst/nextcloud_sentry/commit/bf3cec427c88c29389aaa1c487f6505e8422561b))
+* Do not ship psr/log ([239096f](https://github.com/ChristophWurst/nextcloud_sentry/commit/239096ff044b5581380dfcd4728f175188d31fde))
+
+
+### Features
+
+* **deps:** Add Nextcloud 31 support ([a8075a4](https://github.com/ChristophWurst/nextcloud_sentry/commit/a8075a4de02ec9ba4f61b1122f0a9dd12459f6e9))
+
+
+
 # [8.11.0](https://github.com/ChristophWurst/nextcloud_sentry/compare/v8.10.1...v8.11.0) (2024-08-29)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [8.12.3](https://github.com/ChristophWurst/nextcloud_sentry/compare/v8.12.2...v8.12.3) (2024-11-18)
+
+
+### Bug Fixes
+
+* **deps:** update dependency @sentry/browser to ^7.120.0 ([#696](https://github.com/ChristophWurst/nextcloud_sentry/issues/696)) ([8654ce2](https://github.com/ChristophWurst/nextcloud_sentry/commit/8654ce2219f2d57f2fa9f7e5770dbbe4c3260e69))
+
+
+
 ## [8.12.2](https://github.com/ChristophWurst/nextcloud_sentry/compare/v8.12.1...v8.12.2) (2024-11-04)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [8.10.1](https://github.com/ChristophWurst/nextcloud_sentry/compare/v8.10.0...v8.10.1) (2024-07-18)
+
+
+### Bug Fixes
+
+* **deps:** update dependency @nextcloud/auth to ^2.3.0 ([fc9c703](https://github.com/ChristophWurst/nextcloud_sentry/commit/fc9c7038d5aaf6bedc39168e126eaebc3f76ece0))
+
+
+
 # [8.10.0](https://github.com/ChristophWurst/nextcloud_sentry/compare/v8.9.9...v8.10.0) (2024-07-17)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [8.12.2](https://github.com/ChristophWurst/nextcloud_sentry/compare/v8.12.1...v8.12.2) (2024-11-04)
+
+
+### Bug Fixes
+
+* **deps:** update dependency php-http/curl-client to ^2.3.3 ([#694](https://github.com/ChristophWurst/nextcloud_sentry/issues/694)) ([5a6145c](https://github.com/ChristophWurst/nextcloud_sentry/commit/5a6145c33806ea2062488c06c9e1779f91098538))
+
+
+
 ## [8.12.1](https://github.com/ChristophWurst/nextcloud_sentry/compare/v8.12.0...v8.12.1) (2024-10-28)
 
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<name>Sentry</name>
 	<summary>Sentry client</summary>
 	<description>A Sentry integration that sends unhandled exceptions to a Sentry instance to aggregate application crashes. You either have to set up your own Sentry instance or use your sentry.io account. See the admin documentation for how to configure this app.</description>
-	<version>8.9.9</version>
+	<version>8.10.0</version>
 	<licence>agpl</licence>
 	<author>Christoph Wurst</author>
 	<author>Morris Jobke</author>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<name>Sentry</name>
 	<summary>Sentry client</summary>
 	<description>A Sentry integration that sends unhandled exceptions to a Sentry instance to aggregate application crashes. You either have to set up your own Sentry instance or use your sentry.io account. See the admin documentation for how to configure this app.</description>
-	<version>8.12.0</version>
+	<version>8.12.1</version>
 	<licence>agpl</licence>
 	<author>Christoph Wurst</author>
 	<author>Morris Jobke</author>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -23,7 +23,7 @@
 	<repository>https://github.com/ChristophWurst/nextcloud_sentry</repository>
 	<dependencies>
 		<php min-version="8.0" max-version="8.3" />
-		<nextcloud min-version="26" max-version="30" />
+		<nextcloud min-version="26" max-version="31" />
 	</dependencies>
 	<commands>
 		<command>OCA\Sentry\Command\Test</command>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<name>Sentry</name>
 	<summary>Sentry client</summary>
 	<description>A Sentry integration that sends unhandled exceptions to a Sentry instance to aggregate application crashes. You either have to set up your own Sentry instance or use your sentry.io account. See the admin documentation for how to configure this app.</description>
-	<version>8.10.0</version>
+	<version>8.10.1</version>
 	<licence>agpl</licence>
 	<author>Christoph Wurst</author>
 	<author>Morris Jobke</author>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -23,7 +23,7 @@
 	<repository>https://github.com/ChristophWurst/nextcloud_sentry</repository>
 	<dependencies>
 		<php min-version="8.0" max-version="8.3" />
-		<nextcloud min-version="24" max-version="29" />
+		<nextcloud min-version="26" max-version="30" />
 	</dependencies>
 	<commands>
 		<command>OCA\Sentry\Command\Test</command>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<name>Sentry</name>
 	<summary>Sentry client</summary>
 	<description>A Sentry integration that sends unhandled exceptions to a Sentry instance to aggregate application crashes. You either have to set up your own Sentry instance or use your sentry.io account. See the admin documentation for how to configure this app.</description>
-	<version>8.10.1</version>
+	<version>8.11.0</version>
 	<licence>agpl</licence>
 	<author>Christoph Wurst</author>
 	<author>Morris Jobke</author>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<name>Sentry</name>
 	<summary>Sentry client</summary>
 	<description>A Sentry integration that sends unhandled exceptions to a Sentry instance to aggregate application crashes. You either have to set up your own Sentry instance or use your sentry.io account. See the admin documentation for how to configure this app.</description>
-	<version>8.12.1</version>
+	<version>8.12.2</version>
 	<licence>agpl</licence>
 	<author>Christoph Wurst</author>
 	<author>Morris Jobke</author>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<name>Sentry</name>
 	<summary>Sentry client</summary>
 	<description>A Sentry integration that sends unhandled exceptions to a Sentry instance to aggregate application crashes. You either have to set up your own Sentry instance or use your sentry.io account. See the admin documentation for how to configure this app.</description>
-	<version>8.12.2</version>
+	<version>8.12.3</version>
 	<licence>agpl</licence>
 	<author>Christoph Wurst</author>
 	<author>Morris Jobke</author>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<name>Sentry</name>
 	<summary>Sentry client</summary>
 	<description>A Sentry integration that sends unhandled exceptions to a Sentry instance to aggregate application crashes. You either have to set up your own Sentry instance or use your sentry.io account. See the admin documentation for how to configure this app.</description>
-	<version>8.11.0</version>
+	<version>8.12.0</version>
 	<licence>agpl</licence>
 	<author>Christoph Wurst</author>
 	<author>Morris Jobke</author>

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 	},
 	"require": {
 		"php": "^8.0 <= 8.1",
-		"nyholm/psr7": "^1.8.1",
+		"nyholm/psr7": "^1.8.2",
 		"php-http/curl-client": "^2.3.2",
 		"psr/log": "^1",
 		"sentry/sentry": "^3.22.1",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
 	"require-dev": {
 		"christophwurst/nextcloud_testing": "^1.0.0",
 		"roave/security-advisories": "dev-master",
-		"psalm/phar": "^5.23.1"
+		"psalm/phar": "^5.25.0"
 	},
 	"scripts": {
 		"lint": "find . -name \\*.php -not -path './vendor/*' -not -path './build/*' -print0 | xargs -0 -n1 php -l",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
 	"require-dev": {
 		"christophwurst/nextcloud_testing": "^1.0.0",
 		"roave/security-advisories": "dev-master",
-		"psalm/phar": "^5.25.0"
+		"psalm/phar": "^5.26.1"
 	},
 	"scripts": {
 		"lint": "find . -name \\*.php -not -path './vendor/*' -not -path './build/*' -print0 | xargs -0 -n1 php -l",

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,9 @@
 		"sentry/sentry": "^3.22.1",
 		"guzzlehttp/promises": "^1.5.3"
 	},
+	"provide": {
+		"psr/log": "^1.0.4|^2|^3"
+	},
 	"require-dev": {
 		"christophwurst/nextcloud_testing": "^1.0.0",
 		"roave/security-advisories": "dev-master",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 	"require": {
 		"php": "^8.0 <= 8.1",
 		"nyholm/psr7": "^1.8.2",
-		"php-http/curl-client": "^2.3.2",
+		"php-http/curl-client": "^2.3.3",
 		"psr/log": "^1",
 		"sentry/sentry": "^3.22.1",
 		"guzzlehttp/promises": "^1.5.3"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4ef63abc3c596eb79f861014cf230cbc",
+    "content-hash": "dd54614f415674ee0df53a4e751e479f",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -2165,16 +2165,16 @@
         },
         {
             "name": "psalm/phar",
-            "version": "5.23.1",
+            "version": "5.25.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/psalm/phar.git",
-                "reference": "07bb50acefdaf7b663087186f86d47542a9b1622"
+                "reference": "d42708449bd2d99ec6509924332fd94263974b20"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/psalm/phar/zipball/07bb50acefdaf7b663087186f86d47542a9b1622",
-                "reference": "07bb50acefdaf7b663087186f86d47542a9b1622",
+                "url": "https://api.github.com/repos/psalm/phar/zipball/d42708449bd2d99ec6509924332fd94263974b20",
+                "reference": "d42708449bd2d99ec6509924332fd94263974b20",
                 "shasum": ""
             },
             "require": {
@@ -2194,9 +2194,9 @@
             "description": "Composer-based Psalm Phar",
             "support": {
                 "issues": "https://github.com/psalm/phar/issues",
-                "source": "https://github.com/psalm/phar/tree/5.23.1"
+                "source": "https://github.com/psalm/phar/tree/5.25.0"
             },
-            "time": "2024-03-11T20:43:33+00:00"
+            "time": "2024-06-19T20:02:02+00:00"
         },
         {
             "name": "roave/security-advisories",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "32c6285aba26beb6158075915835e83a",
+    "content-hash": "eabf38a87266b6367ff0409b5073221b",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -2115,16 +2115,16 @@
         },
         {
             "name": "psalm/phar",
-            "version": "5.25.0",
+            "version": "5.26.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/psalm/phar.git",
-                "reference": "d42708449bd2d99ec6509924332fd94263974b20"
+                "reference": "8a38e7ad04499a0ccd2c506fd1da6fc01fff4547"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/psalm/phar/zipball/d42708449bd2d99ec6509924332fd94263974b20",
-                "reference": "d42708449bd2d99ec6509924332fd94263974b20",
+                "url": "https://api.github.com/repos/psalm/phar/zipball/8a38e7ad04499a0ccd2c506fd1da6fc01fff4547",
+                "reference": "8a38e7ad04499a0ccd2c506fd1da6fc01fff4547",
                 "shasum": ""
             },
             "require": {
@@ -2144,9 +2144,9 @@
             "description": "Composer-based Psalm Phar",
             "support": {
                 "issues": "https://github.com/psalm/phar/issues",
-                "source": "https://github.com/psalm/phar/tree/5.25.0"
+                "source": "https://github.com/psalm/phar/tree/5.26.1"
             },
-            "time": "2024-06-19T20:02:02+00:00"
+            "time": "2024-09-09T16:22:43+00:00"
         },
         {
             "name": "roave/security-advisories",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eabf38a87266b6367ff0409b5073221b",
+    "content-hash": "86c5f5692aba8a8b594f3e6befea02b0",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -359,16 +359,16 @@
         },
         {
             "name": "php-http/curl-client",
-            "version": "2.3.2",
+            "version": "2.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-http/curl-client.git",
-                "reference": "0b869922458b1cde9137374545ed4fff7ac83623"
+                "reference": "f3eb48d266341afec0229a7a37a03521d3646b81"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-http/curl-client/zipball/0b869922458b1cde9137374545ed4fff7ac83623",
-                "reference": "0b869922458b1cde9137374545ed4fff7ac83623",
+                "url": "https://api.github.com/repos/php-http/curl-client/zipball/f3eb48d266341afec0229a7a37a03521d3646b81",
+                "reference": "f3eb48d266341afec0229a7a37a03521d3646b81",
                 "shasum": ""
             },
             "require": {
@@ -388,7 +388,7 @@
             },
             "require-dev": {
                 "guzzlehttp/psr7": "^2.0",
-                "laminas/laminas-diactoros": "^2.0",
+                "laminas/laminas-diactoros": "^2.0 || ^3.0",
                 "php-http/client-integration-tests": "^3.0",
                 "php-http/message-factory": "^1.1",
                 "phpunit/phpunit": "^7.5 || ^9.4"
@@ -418,22 +418,22 @@
             ],
             "support": {
                 "issues": "https://github.com/php-http/curl-client/issues",
-                "source": "https://github.com/php-http/curl-client/tree/2.3.2"
+                "source": "https://github.com/php-http/curl-client/tree/2.3.3"
             },
-            "time": "2024-03-03T08:21:07+00:00"
+            "time": "2024-10-31T07:36:58+00:00"
         },
         {
             "name": "php-http/discovery",
-            "version": "1.19.2",
+            "version": "1.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-http/discovery.git",
-                "reference": "61e1a1eb69c92741f5896d9e05fb8e9d7e8bb0cb"
+                "reference": "82fe4c73ef3363caed49ff8dd1539ba06044910d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-http/discovery/zipball/61e1a1eb69c92741f5896d9e05fb8e9d7e8bb0cb",
-                "reference": "61e1a1eb69c92741f5896d9e05fb8e9d7e8bb0cb",
+                "url": "https://api.github.com/repos/php-http/discovery/zipball/82fe4c73ef3363caed49ff8dd1539ba06044910d",
+                "reference": "82fe4c73ef3363caed49ff8dd1539ba06044910d",
                 "shasum": ""
             },
             "require": {
@@ -457,7 +457,8 @@
                 "php-http/httplug": "^1.0 || ^2.0",
                 "php-http/message-factory": "^1.0",
                 "phpspec/phpspec": "^5.1 || ^6.1 || ^7.3",
-                "symfony/phpunit-bridge": "^6.2"
+                "sebastian/comparator": "^3.0.5 || ^4.0.8",
+                "symfony/phpunit-bridge": "^6.4.4 || ^7.0.1"
             },
             "type": "composer-plugin",
             "extra": {
@@ -496,22 +497,22 @@
             ],
             "support": {
                 "issues": "https://github.com/php-http/discovery/issues",
-                "source": "https://github.com/php-http/discovery/tree/1.19.2"
+                "source": "https://github.com/php-http/discovery/tree/1.20.0"
             },
-            "time": "2023-11-30T16:49:05+00:00"
+            "time": "2024-10-02T11:20:13+00:00"
         },
         {
             "name": "php-http/httplug",
-            "version": "2.4.0",
+            "version": "2.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-http/httplug.git",
-                "reference": "625ad742c360c8ac580fcc647a1541d29e257f67"
+                "reference": "5cad731844891a4c282f3f3e1b582c46839d22f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-http/httplug/zipball/625ad742c360c8ac580fcc647a1541d29e257f67",
-                "reference": "625ad742c360c8ac580fcc647a1541d29e257f67",
+                "url": "https://api.github.com/repos/php-http/httplug/zipball/5cad731844891a4c282f3f3e1b582c46839d22f4",
+                "reference": "5cad731844891a4c282f3f3e1b582c46839d22f4",
                 "shasum": ""
             },
             "require": {
@@ -553,22 +554,22 @@
             ],
             "support": {
                 "issues": "https://github.com/php-http/httplug/issues",
-                "source": "https://github.com/php-http/httplug/tree/2.4.0"
+                "source": "https://github.com/php-http/httplug/tree/2.4.1"
             },
-            "time": "2023-04-14T15:10:03+00:00"
+            "time": "2024-09-23T11:39:58+00:00"
         },
         {
             "name": "php-http/message",
-            "version": "1.16.0",
+            "version": "1.16.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-http/message.git",
-                "reference": "47a14338bf4ebd67d317bf1144253d7db4ab55fd"
+                "reference": "06dd5e8562f84e641bf929bfe699ee0f5ce8080a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-http/message/zipball/47a14338bf4ebd67d317bf1144253d7db4ab55fd",
-                "reference": "47a14338bf4ebd67d317bf1144253d7db4ab55fd",
+                "url": "https://api.github.com/repos/php-http/message/zipball/06dd5e8562f84e641bf929bfe699ee0f5ce8080a",
+                "reference": "06dd5e8562f84e641bf929bfe699ee0f5ce8080a",
                 "shasum": ""
             },
             "require": {
@@ -622,9 +623,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-http/message/issues",
-                "source": "https://github.com/php-http/message/tree/1.16.0"
+                "source": "https://github.com/php-http/message/tree/1.16.2"
             },
-            "time": "2023-05-17T06:43:38+00:00"
+            "time": "2024-10-02T11:34:13+00:00"
         },
         {
             "name": "php-http/message-factory",
@@ -683,16 +684,16 @@
         },
         {
             "name": "php-http/promise",
-            "version": "1.3.0",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-http/promise.git",
-                "reference": "2916a606d3b390f4e9e8e2b8dd68581508be0f07"
+                "reference": "fc85b1fba37c169a69a07ef0d5a8075770cc1f83"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-http/promise/zipball/2916a606d3b390f4e9e8e2b8dd68581508be0f07",
-                "reference": "2916a606d3b390f4e9e8e2b8dd68581508be0f07",
+                "url": "https://api.github.com/repos/php-http/promise/zipball/fc85b1fba37c169a69a07ef0d5a8075770cc1f83",
+                "reference": "fc85b1fba37c169a69a07ef0d5a8075770cc1f83",
                 "shasum": ""
             },
             "require": {
@@ -729,9 +730,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-http/promise/issues",
-                "source": "https://github.com/php-http/promise/tree/1.3.0"
+                "source": "https://github.com/php-http/promise/tree/1.3.1"
             },
-            "time": "2024-01-04T18:49:48+00:00"
+            "time": "2024-03-15T13:55:21+00:00"
         },
         {
             "name": "psr/http-client",
@@ -995,16 +996,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v2.5.2",
+            "version": "v2.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "e8b495ea28c1d97b5e0c121748d6f9b53d075c66"
+                "reference": "80d075412b557d41002320b96a096ca65aa2c98d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/e8b495ea28c1d97b5e0c121748d6f9b53d075c66",
-                "reference": "e8b495ea28c1d97b5e0c121748d6f9b53d075c66",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/80d075412b557d41002320b96a096ca65aa2c98d",
+                "reference": "80d075412b557d41002320b96a096ca65aa2c98d",
                 "shasum": ""
             },
             "require": {
@@ -1042,7 +1043,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.2"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.3"
             },
             "funding": [
                 {
@@ -1058,20 +1059,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-02T09:53:40+00:00"
+            "time": "2023-01-24T14:02:46+00:00"
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v5.4.21",
+            "version": "v5.4.45",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "4fe5cf6ede71096839f0e4b4444d65dd3a7c1eb9"
+                "reference": "74e5b6f0db3e8589e6cfd5efb317a1fc2bb52fb6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/4fe5cf6ede71096839f0e4b4444d65dd3a7c1eb9",
-                "reference": "4fe5cf6ede71096839f0e4b4444d65dd3a7c1eb9",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/74e5b6f0db3e8589e6cfd5efb317a1fc2bb52fb6",
+                "reference": "74e5b6f0db3e8589e6cfd5efb317a1fc2bb52fb6",
                 "shasum": ""
             },
             "require": {
@@ -1111,7 +1112,7 @@
                 "options"
             ],
             "support": {
-                "source": "https://github.com/symfony/options-resolver/tree/v5.4.21"
+                "source": "https://github.com/symfony/options-resolver/tree/v5.4.45"
             },
             "funding": [
                 {
@@ -1127,24 +1128,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-14T08:03:56+00:00"
+            "time": "2024-09-25T14:11:13+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.29.0",
+            "version": "v1.31.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "21bd091060673a1177ae842c0ef8fe30893114d2"
+                "reference": "0f68c03565dcaaf25a890667542e8bd75fe7e5bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/21bd091060673a1177ae842c0ef8fe30893114d2",
-                "reference": "21bd091060673a1177ae842c0ef8fe30893114d2",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/0f68c03565dcaaf25a890667542e8bd75fe7e5bb",
+                "reference": "0f68c03565dcaaf25a890667542e8bd75fe7e5bb",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.2"
             },
             "type": "library",
             "extra": {
@@ -1187,7 +1188,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/v1.29.0"
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.31.0"
             },
             "funding": [
                 {
@@ -1203,24 +1204,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-29T20:11:03+00:00"
+            "time": "2024-09-09T11:45:10+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.29.0",
+            "version": "v1.31.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "87b68208d5c1188808dd7839ee1e6c8ec3b02f1b"
+                "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/87b68208d5c1188808dd7839ee1e6c8ec3b02f1b",
-                "reference": "87b68208d5c1188808dd7839ee1e6c8ec3b02f1b",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
+                "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.2"
             },
             "type": "library",
             "extra": {
@@ -1267,7 +1268,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.29.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.31.0"
             },
             "funding": [
                 {
@@ -1283,7 +1284,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-29T20:11:03+00:00"
+            "time": "2024-09-09T11:45:10+00:00"
         }
     ],
     "packages-dev": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0453ec57a997956eb527aee66d774c01",
+    "content-hash": "32c6285aba26beb6158075915835e83a",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -212,16 +212,16 @@
         },
         {
             "name": "nyholm/psr7",
-            "version": "1.8.1",
+            "version": "1.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Nyholm/psr7.git",
-                "reference": "aa5fc277a4f5508013d571341ade0c3886d4d00e"
+                "reference": "a71f2b11690f4b24d099d6b16690a90ae14fc6f3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Nyholm/psr7/zipball/aa5fc277a4f5508013d571341ade0c3886d4d00e",
-                "reference": "aa5fc277a4f5508013d571341ade0c3886d4d00e",
+                "url": "https://api.github.com/repos/Nyholm/psr7/zipball/a71f2b11690f4b24d099d6b16690a90ae14fc6f3",
+                "reference": "a71f2b11690f4b24d099d6b16690a90ae14fc6f3",
                 "shasum": ""
             },
             "require": {
@@ -274,7 +274,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Nyholm/psr7/issues",
-                "source": "https://github.com/Nyholm/psr7/tree/1.8.1"
+                "source": "https://github.com/Nyholm/psr7/tree/1.8.2"
             },
             "funding": [
                 {
@@ -286,7 +286,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-11-13T09:31:12+00:00"
+            "time": "2024-09-09T07:06:30+00:00"
         },
         {
             "name": "php-http/client-common",
@@ -787,20 +787,20 @@
         },
         {
             "name": "psr/http-factory",
-            "version": "1.0.2",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-factory.git",
-                "reference": "e616d01114759c4c489f93b099585439f795fe35"
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/e616d01114759c4c489f93b099585439f795fe35",
-                "reference": "e616d01114759c4c489f93b099585439f795fe35",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0.0",
+                "php": ">=7.1",
                 "psr/http-message": "^1.0 || ^2.0"
             },
             "type": "library",
@@ -824,7 +824,7 @@
                     "homepage": "https://www.php-fig.org/"
                 }
             ],
-            "description": "Common interfaces for PSR-7 HTTP message factories",
+            "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
             "keywords": [
                 "factory",
                 "http",
@@ -836,9 +836,9 @@
                 "response"
             ],
             "support": {
-                "source": "https://github.com/php-fig/http-factory/tree/1.0.2"
+                "source": "https://github.com/php-fig/http-factory"
             },
-            "time": "2023-04-10T20:10:41+00:00"
+            "time": "2024-04-15T12:06:14+00:00"
         },
         {
             "name": "psr/http-message",
@@ -4019,7 +4019,7 @@
     "platform": {
         "php": "^8.0 <= 8.1"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dd54614f415674ee0df53a4e751e479f",
+    "content-hash": "0453ec57a997956eb527aee66d774c01",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -892,56 +892,6 @@
                 "source": "https://github.com/php-fig/http-message/tree/2.0"
             },
             "time": "2023-04-04T09:54:51+00:00"
-        },
-        {
-            "name": "psr/log",
-            "version": "1.1.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/log.git",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Log\\": "Psr/Log/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for logging libraries",
-            "homepage": "https://github.com/php-fig/log",
-            "keywords": [
-                "log",
-                "psr",
-                "psr-3"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/log/tree/1.1.4"
-            },
-            "time": "2021-05-03T11:20:27+00:00"
         },
         {
             "name": "sentry/sentry",

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -75,6 +75,7 @@ class Application extends App implements IBootstrap {
 					'release' => $config->getServerVersion(),
 					'traces_sample_rate' => $config->getSamplingRate(),
 					'profiles_sample_rate' => $config->getProfilesSamplingRate(),
+					'environment' => $config->getEnvironment(),
 				]);
 			}
 		});

--- a/lib/Command/Test.php
+++ b/lib/Command/Test.php
@@ -26,19 +26,15 @@ declare(strict_types=1);
 
 namespace OCA\Sentry\Command;
 
-use OCP\ILogger;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 
 class Test extends Command {
-	/** @var ILogger */
-	private $logger;
-
-	public function __construct(ILogger $logger) {
+	public function __construct(private LoggerInterface $logger) {
 		parent::__construct();
-		$this->logger = $logger;
 	}
 
 	protected function configure(): void {
@@ -53,7 +49,7 @@ class Test extends Command {
 			$this->logger->emergency("This is a sentry emergency test message");
 			throw new \Exception('This is a sentry test exception!');
 		} catch (Throwable $e) {
-			$this->logger->logException($e, ['app' => 'sentry']);
+			$this->logger->error($e->getMessage(), ['exception' => $e]);
 		}
 		return 0;
 	}

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -96,4 +96,8 @@ class Config {
 			default => 0.1,
 		};
 	}
+
+	public function getEnvironment(): string {
+		return $this->config->getSystemValue('sentry.environment', 'production');
+	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nextcloud_sentry",
-  "version": "8.12.1",
+  "version": "8.12.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,10 +6,10 @@
   "packages": {
     "": {
       "name": "nextcloud_sentry",
-      "version": "8.10.0",
+      "version": "8.11.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
-        "@nextcloud/auth": "^2.3.0",
+        "@nextcloud/auth": "^2.4.0",
         "@nextcloud/initial-state": "^2.2.0",
         "@nextcloud/logger": "^3.0.2",
         "@sentry/browser": "^7.118.0"
@@ -88,11 +88,24 @@
       }
     },
     "node_modules/@nextcloud/auth": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-2.3.0.tgz",
-      "integrity": "sha512-PCkRJbML9sXvBENY43vTIERIZJFk2azu08IK6zYOnOZ7cFkD1QlFJtdTCZTImQLg01IXhIm0j0ExEdatHoqz7g==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-2.4.0.tgz",
+      "integrity": "sha512-T5OFltKd0O9Hfj47VrzE7TVjCwqOMHH9JLyjjLUR3pu2MaTY9WL6AjL79sHbFTXUaIkftZgJKu12lHYmqXnL2Q==",
       "dependencies": {
-        "@nextcloud/event-bus": "^3.2.0"
+        "@nextcloud/browser-storage": "^0.4.0",
+        "@nextcloud/event-bus": "^3.3.1"
+      },
+      "engines": {
+        "node": "^20.0.0",
+        "npm": "^10.0.0"
+      }
+    },
+    "node_modules/@nextcloud/browser-storage": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/browser-storage/-/browser-storage-0.4.0.tgz",
+      "integrity": "sha512-D6XxznxCYmJ3oBCC3p0JB6GZJ2RZ9dgbB1UqtTePXrIvHUMBAeF/YkiGKYxLAVZCZb+NSNZXgAYHm/3LnIUbDg==",
+      "dependencies": {
+        "core-js": "3.37.0"
       },
       "engines": {
         "node": "^20.0.0",
@@ -633,6 +646,16 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
+    },
+    "node_modules/core-js": {
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.37.0.tgz",
+      "integrity": "sha512-fu5vHevQ8ZG4og+LXug8ulUtVxjOcEYvifJr7L5Bfq9GOztVqsKd9/59hUk2ZSbCrS3BqUr3EpaYGIYzq7g3Ug==",
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -1635,11 +1658,20 @@
       }
     },
     "@nextcloud/auth": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-2.3.0.tgz",
-      "integrity": "sha512-PCkRJbML9sXvBENY43vTIERIZJFk2azu08IK6zYOnOZ7cFkD1QlFJtdTCZTImQLg01IXhIm0j0ExEdatHoqz7g==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-2.4.0.tgz",
+      "integrity": "sha512-T5OFltKd0O9Hfj47VrzE7TVjCwqOMHH9JLyjjLUR3pu2MaTY9WL6AjL79sHbFTXUaIkftZgJKu12lHYmqXnL2Q==",
       "requires": {
-        "@nextcloud/event-bus": "^3.2.0"
+        "@nextcloud/browser-storage": "^0.4.0",
+        "@nextcloud/event-bus": "^3.3.1"
+      }
+    },
+    "@nextcloud/browser-storage": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/browser-storage/-/browser-storage-0.4.0.tgz",
+      "integrity": "sha512-D6XxznxCYmJ3oBCC3p0JB6GZJ2RZ9dgbB1UqtTePXrIvHUMBAeF/YkiGKYxLAVZCZb+NSNZXgAYHm/3LnIUbDg==",
+      "requires": {
+        "core-js": "3.37.0"
       }
     },
     "@nextcloud/event-bus": {
@@ -2060,6 +2092,11 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
+    },
+    "core-js": {
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.37.0.tgz",
+      "integrity": "sha512-fu5vHevQ8ZG4og+LXug8ulUtVxjOcEYvifJr7L5Bfq9GOztVqsKd9/59hUk2ZSbCrS3BqUr3EpaYGIYzq7g3Ug=="
     },
     "cross-spawn": {
       "version": "7.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
       "devDependencies": {
         "webpack": "^5.93.0",
         "webpack-cli": "^5.1.4",
-        "webpack-merge": "^5.10.0"
+        "webpack-merge": "^6.0.1"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -1531,7 +1531,7 @@
         "node": ">=14"
       }
     },
-    "node_modules/webpack-merge": {
+    "node_modules/webpack-cli/node_modules/webpack-merge": {
       "version": "5.10.0",
       "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
       "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
@@ -1543,6 +1543,20 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/webpack-merge": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-6.0.1.tgz",
+      "integrity": "sha512-hXXvrjtx2PLYx4qruKl+kyRSLc52V+cCvMxRjmKwoA+CBbbF5GfIBtR6kCvl0fYGqTUPKB+1ktVmTHqMOzgCBg==",
+      "dev": true,
+      "dependencies": {
+        "clone-deep": "^4.0.1",
+        "flat": "^5.0.2",
+        "wildcard": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/webpack-sources": {
@@ -1570,9 +1584,9 @@
       }
     },
     "node_modules/wildcard": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
-      "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
+      "integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==",
       "dev": true
     }
   },
@@ -2684,18 +2698,29 @@
           "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
           "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
           "dev": true
+        },
+        "webpack-merge": {
+          "version": "5.10.0",
+          "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+          "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+          "dev": true,
+          "requires": {
+            "clone-deep": "^4.0.1",
+            "flat": "^5.0.2",
+            "wildcard": "^2.0.0"
+          }
         }
       }
     },
     "webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-6.0.1.tgz",
+      "integrity": "sha512-hXXvrjtx2PLYx4qruKl+kyRSLc52V+cCvMxRjmKwoA+CBbbF5GfIBtR6kCvl0fYGqTUPKB+1ktVmTHqMOzgCBg==",
       "dev": true,
       "requires": {
         "clone-deep": "^4.0.1",
         "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
+        "wildcard": "^2.0.1"
       }
     },
     "webpack-sources": {
@@ -2714,9 +2739,9 @@
       }
     },
     "wildcard": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
-      "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
+      "integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==",
       "dev": true
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nextcloud_sentry",
-  "version": "8.10.0",
+  "version": "8.10.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,11 +6,11 @@
   "packages": {
     "": {
       "name": "nextcloud_sentry",
-      "version": "8.9.8",
+      "version": "8.9.9",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.2.1",
-        "@nextcloud/initial-state": "^2.1.0",
+        "@nextcloud/initial-state": "^2.2.0",
         "@nextcloud/logger": "^2.7.0",
         "@sentry/browser": "^7.108.0"
       },
@@ -112,12 +112,12 @@
       }
     },
     "node_modules/@nextcloud/initial-state": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/initial-state/-/initial-state-2.1.0.tgz",
-      "integrity": "sha512-b92X/GvUPGQJpUQwauyG3D3dHsWowViVLnTtFPSMUc0rXtvYR5CvhkqJRfPC7O7W4VC7+V3q+FWeA+mQWMxN2Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/initial-state/-/initial-state-2.2.0.tgz",
+      "integrity": "sha512-cDW98L5KGGgpS8pzd+05304/p80cyu8U2xSDQGa+kGPTpUFmCbv2qnO5WrwwGTauyjYijCal2bmw82VddSH+Pg==",
       "engines": {
         "node": "^20.0.0",
-        "npm": "^9.0.0"
+        "npm": "^10.0.0"
       }
     },
     "node_modules/@nextcloud/logger": {
@@ -1624,9 +1624,9 @@
       }
     },
     "@nextcloud/initial-state": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/initial-state/-/initial-state-2.1.0.tgz",
-      "integrity": "sha512-b92X/GvUPGQJpUQwauyG3D3dHsWowViVLnTtFPSMUc0rXtvYR5CvhkqJRfPC7O7W4VC7+V3q+FWeA+mQWMxN2Q=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/initial-state/-/initial-state-2.2.0.tgz",
+      "integrity": "sha512-cDW98L5KGGgpS8pzd+05304/p80cyu8U2xSDQGa+kGPTpUFmCbv2qnO5WrwwGTauyjYijCal2bmw82VddSH+Pg=="
     },
     "@nextcloud/logger": {
       "version": "2.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,10 +6,10 @@
   "packages": {
     "": {
       "name": "nextcloud_sentry",
-      "version": "8.9.9",
+      "version": "8.10.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
-        "@nextcloud/auth": "^2.2.1",
+        "@nextcloud/auth": "^2.3.0",
         "@nextcloud/initial-state": "^2.2.0",
         "@nextcloud/logger": "^2.7.0",
         "@sentry/browser": "^7.118.0"
@@ -88,27 +88,28 @@
       }
     },
     "node_modules/@nextcloud/auth": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-2.2.1.tgz",
-      "integrity": "sha512-zYtgrg9NMZfN8kmL5JPCsh5jDhpTCEslhnZWMvbhTiQ7hrOnji/67ok6VMK0CTJ1a92Vr67Ow72lW7YRX69zEA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-2.3.0.tgz",
+      "integrity": "sha512-PCkRJbML9sXvBENY43vTIERIZJFk2azu08IK6zYOnOZ7cFkD1QlFJtdTCZTImQLg01IXhIm0j0ExEdatHoqz7g==",
       "dependencies": {
-        "@nextcloud/event-bus": "^3.1.0"
+        "@nextcloud/event-bus": "^3.2.0"
       },
       "engines": {
         "node": "^20.0.0",
-        "npm": "^9.0.0"
+        "npm": "^10.0.0"
       }
     },
     "node_modules/@nextcloud/event-bus": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-3.1.0.tgz",
-      "integrity": "sha512-purXQsXbhbmpcDsbDuR0i7vwUgOsqnIUa7QAD3lV/UZUkUT94SmxBM5LgQ8iV8TQBWWleEwQHy5kYfHeTGF9wg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-3.3.1.tgz",
+      "integrity": "sha512-VBYJspOVk5aZopgZwCUoMKFqcTLCNel2TLvtu0HMPV2gR5ZLPiPAKbkyKkYTh+Sd5QB1gR6l3STTv1gyal0soQ==",
       "dependencies": {
-        "semver": "^7.5.1"
+        "@types/node": "^20.12.12",
+        "semver": "^7.6.2"
       },
       "engines": {
-        "node": "^16.0.0",
-        "npm": "^7.0.0 || ^8.0.0"
+        "node": "^20.0.0",
+        "npm": "^10.0.0"
       }
     },
     "node_modules/@nextcloud/initial-state": {
@@ -283,10 +284,12 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.0.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.13.tgz",
-      "integrity": "sha512-rouEWBImiRaSJsVA+ITTFM6ZxibuAlTuNOCyxVbwreu6k6+ujs7DfnU9o+PShFhET78pMBl3eH+AGSI5eOTkPA==",
-      "dev": true
+      "version": "20.14.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.11.tgz",
+      "integrity": "sha512-kprQpL8MMeszbz6ojB5/tU8PLN4kesnN8Gjzw349rDlNgsSzg90lAVj3llK99Dh7JON+t9AuscPPFW6mPbTnSA==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.12.1",
@@ -996,17 +999,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -1231,12 +1223,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -1383,6 +1372,11 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
       "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
       "dev": true
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/update-browserslist-db": {
       "version": "1.0.13",
@@ -1580,11 +1574,6 @@
       "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
       "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
       "dev": true
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   },
   "dependencies": {
@@ -1644,19 +1633,20 @@
       }
     },
     "@nextcloud/auth": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-2.2.1.tgz",
-      "integrity": "sha512-zYtgrg9NMZfN8kmL5JPCsh5jDhpTCEslhnZWMvbhTiQ7hrOnji/67ok6VMK0CTJ1a92Vr67Ow72lW7YRX69zEA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-2.3.0.tgz",
+      "integrity": "sha512-PCkRJbML9sXvBENY43vTIERIZJFk2azu08IK6zYOnOZ7cFkD1QlFJtdTCZTImQLg01IXhIm0j0ExEdatHoqz7g==",
       "requires": {
-        "@nextcloud/event-bus": "^3.1.0"
+        "@nextcloud/event-bus": "^3.2.0"
       }
     },
     "@nextcloud/event-bus": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-3.1.0.tgz",
-      "integrity": "sha512-purXQsXbhbmpcDsbDuR0i7vwUgOsqnIUa7QAD3lV/UZUkUT94SmxBM5LgQ8iV8TQBWWleEwQHy5kYfHeTGF9wg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-3.3.1.tgz",
+      "integrity": "sha512-VBYJspOVk5aZopgZwCUoMKFqcTLCNel2TLvtu0HMPV2gR5ZLPiPAKbkyKkYTh+Sd5QB1gR6l3STTv1gyal0soQ==",
       "requires": {
-        "semver": "^7.5.1"
+        "@types/node": "^20.12.12",
+        "semver": "^7.6.2"
       }
     },
     "@nextcloud/initial-state": {
@@ -1796,10 +1786,12 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.0.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.13.tgz",
-      "integrity": "sha512-rouEWBImiRaSJsVA+ITTFM6ZxibuAlTuNOCyxVbwreu6k6+ujs7DfnU9o+PShFhET78pMBl3eH+AGSI5eOTkPA==",
-      "dev": true
+      "version": "20.14.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.11.tgz",
+      "integrity": "sha512-kprQpL8MMeszbz6ojB5/tU8PLN4kesnN8Gjzw349rDlNgsSzg90lAVj3llK99Dh7JON+t9AuscPPFW6mPbTnSA==",
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
     },
     "@webassemblyjs/ast": {
       "version": "1.12.1",
@@ -2346,14 +2338,6 @@
         "p-locate": "^4.1.0"
       }
     },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "requires": {
-        "yallist": "^4.0.0"
-      }
-    },
     "merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -2512,12 +2496,9 @@
       }
     },
     "semver": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
-      "requires": {
-        "lru-cache": "^6.0.0"
-      }
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A=="
     },
     "serialize-javascript": {
       "version": "6.0.1",
@@ -2610,6 +2591,11 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
       "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
       "dev": true
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "update-browserslist-db": {
       "version": "1.0.13",
@@ -2732,11 +2718,6 @@
       "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
       "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
       "dev": true
-    },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nextcloud_sentry",
-  "version": "8.12.2",
+  "version": "8.12.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nextcloud_sentry",
-  "version": "8.10.1",
+  "version": "8.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,13 +6,13 @@
   "packages": {
     "": {
       "name": "nextcloud_sentry",
-      "version": "8.9.8",
+      "version": "8.9.9",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.2.1",
         "@nextcloud/initial-state": "^2.1.0",
         "@nextcloud/logger": "^2.7.0",
-        "@sentry/browser": "^7.108.0"
+        "@sentry/browser": "^7.118.0"
       },
       "devDependencies": {
         "webpack": "^5.91.0",
@@ -134,102 +134,117 @@
       }
     },
     "node_modules/@sentry-internal/feedback": {
-      "version": "7.108.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.108.0.tgz",
-      "integrity": "sha512-8JcgZEnk1uWrXJhsd3iRvFtEiVeaWOEhN0NZwhwQXHfvODqep6JtrkY1yCIyxbpA37aZmrPc2JhyotRERGfUjg==",
+      "version": "7.118.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.118.0.tgz",
+      "integrity": "sha512-IYOGRcqIqKJJpMwBBv+0JTu0FPpXnakJYvOx/XEa/SNyF5+l7b9gGEjUVWh1ok50kTLW/XPnpnXNAGQcoKHg+w==",
       "dependencies": {
-        "@sentry/core": "7.108.0",
-        "@sentry/types": "7.108.0",
-        "@sentry/utils": "7.108.0"
+        "@sentry/core": "7.118.0",
+        "@sentry/types": "7.118.0",
+        "@sentry/utils": "7.118.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@sentry-internal/replay-canvas": {
-      "version": "7.108.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.108.0.tgz",
-      "integrity": "sha512-R5tvjGqWUV5vSk0N1eBgVW7wIADinrkfDEBZ9FyKP2mXHBobsyNGt30heJDEqYmVqluRqjU2NuIRapsnnrpGnA==",
+      "version": "7.118.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.118.0.tgz",
+      "integrity": "sha512-XxHlCClvrxmVKpiZetFYyiBaPQNiojoBGFFVgbbWBIAPc+fWeLJ2BMoQEBjn/0NA/8u8T6lErK5YQo/eIx9+XQ==",
       "dependencies": {
-        "@sentry/core": "7.108.0",
-        "@sentry/replay": "7.108.0",
-        "@sentry/types": "7.108.0",
-        "@sentry/utils": "7.108.0"
+        "@sentry/core": "7.118.0",
+        "@sentry/replay": "7.118.0",
+        "@sentry/types": "7.118.0",
+        "@sentry/utils": "7.118.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@sentry-internal/tracing": {
-      "version": "7.108.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.108.0.tgz",
-      "integrity": "sha512-zuK5XsTsb+U+hgn3SPetYDAogrXsM16U/LLoMW7+TlC6UjlHGYQvmX3o+M2vntejoU1QZS8m1bCAZSMWEypAEw==",
+      "version": "7.118.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.118.0.tgz",
+      "integrity": "sha512-dERAshKlQLrBscHSarhHyUeGsu652bDTUN1FK0m4e3X48M3I5/s+0N880Qjpe5MprNLcINlaIgdQ9jkisvxjfw==",
       "dependencies": {
-        "@sentry/core": "7.108.0",
-        "@sentry/types": "7.108.0",
-        "@sentry/utils": "7.108.0"
+        "@sentry/core": "7.118.0",
+        "@sentry/types": "7.118.0",
+        "@sentry/utils": "7.118.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "7.108.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.108.0.tgz",
-      "integrity": "sha512-FNpzsdTvGvdHJMUelqEouUXMZU7jC+dpN7CdT6IoHVVFEkoAgrjMVUhXZoQ/dmCkdKWHmFSQhJ8Fm6V+e9Aq0A==",
+      "version": "7.118.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.118.0.tgz",
+      "integrity": "sha512-8onDOFV1VLEoBuqA5yaJeR3FF1JNuxr5C7p1oN3OwY724iTVqQnOLmZKZaSnHV3RkY67wKDGQkQIie14sc+42g==",
       "dependencies": {
-        "@sentry-internal/feedback": "7.108.0",
-        "@sentry-internal/replay-canvas": "7.108.0",
-        "@sentry-internal/tracing": "7.108.0",
-        "@sentry/core": "7.108.0",
-        "@sentry/replay": "7.108.0",
-        "@sentry/types": "7.108.0",
-        "@sentry/utils": "7.108.0"
+        "@sentry-internal/feedback": "7.118.0",
+        "@sentry-internal/replay-canvas": "7.118.0",
+        "@sentry-internal/tracing": "7.118.0",
+        "@sentry/core": "7.118.0",
+        "@sentry/integrations": "7.118.0",
+        "@sentry/replay": "7.118.0",
+        "@sentry/types": "7.118.0",
+        "@sentry/utils": "7.118.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/core": {
-      "version": "7.108.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.108.0.tgz",
-      "integrity": "sha512-I/VNZCFgLASxHZaD0EtxZRM34WG9w2gozqgrKGNMzAymwmQ3K9g/1qmBy4e6iS3YRptb7J5UhQkZQHrcwBbjWQ==",
+      "version": "7.118.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.118.0.tgz",
+      "integrity": "sha512-ol0xBdp3/K11IMAYSQE0FMxBOOH9hMsb/rjxXWe0hfM5c72CqYWL3ol7voPci0GELJ5CZG+9ImEU1V9r6gK64g==",
       "dependencies": {
-        "@sentry/types": "7.108.0",
-        "@sentry/utils": "7.108.0"
+        "@sentry/types": "7.118.0",
+        "@sentry/utils": "7.118.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/integrations": {
+      "version": "7.118.0",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.118.0.tgz",
+      "integrity": "sha512-C2rR4NvIMjokF8jP5qzSf1o2zxDx7IeYnr8u15Kb2+HdZtX559owALR0hfgwnfeElqMhGlJBaKUWZ48lXJMzCQ==",
+      "dependencies": {
+        "@sentry/core": "7.118.0",
+        "@sentry/types": "7.118.0",
+        "@sentry/utils": "7.118.0",
+        "localforage": "^1.8.1"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/replay": {
-      "version": "7.108.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.108.0.tgz",
-      "integrity": "sha512-jo8fDOzcZJclP1+4n9jUtVxTlBFT9hXwxhAMrhrt70FV/nfmCtYQMD3bzIj79nwbhUtFP6pN39JH1o7Xqt1hxQ==",
+      "version": "7.118.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.118.0.tgz",
+      "integrity": "sha512-boQfCL+1L/tSZ9Huwi00+VtU+Ih1Lcg8HtxBuAsBCJR9pQgUL5jp7ECYdTeeHyCh/RJO7JqV1CEoGTgohe10mA==",
       "dependencies": {
-        "@sentry-internal/tracing": "7.108.0",
-        "@sentry/core": "7.108.0",
-        "@sentry/types": "7.108.0",
-        "@sentry/utils": "7.108.0"
+        "@sentry-internal/tracing": "7.118.0",
+        "@sentry/core": "7.118.0",
+        "@sentry/types": "7.118.0",
+        "@sentry/utils": "7.118.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@sentry/types": {
-      "version": "7.108.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.108.0.tgz",
-      "integrity": "sha512-bKtHITmBN3kqtqE5eVvL8mY8znM05vEodENwRpcm6TSrrBjC2RnwNWVwGstYDdHpNfFuKwC8mLY9bgMJcENo8g==",
+      "version": "7.118.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.118.0.tgz",
+      "integrity": "sha512-2drqrD2+6kgeg+W/ycmiti3G4lJrV3hGjY9PpJ3bJeXrh6T2+LxKPzlgSEnKFaeQWkXdZ4eaUbtTXVebMjb5JA==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "7.108.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.108.0.tgz",
-      "integrity": "sha512-a45yEFD5qtgZaIFRAcFkG8C8lnDzn6t4LfLXuV4OafGAy/3ZAN3XN8wDnrruHkiUezSSANGsLg3bXaLW/JLvJw==",
+      "version": "7.118.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.118.0.tgz",
+      "integrity": "sha512-43qItc/ydxZV1Zb3Kn2M54RwL9XXFa3IAYBO8S82Qvq5YUYmU2AmJ1jgg7DabXlVSWgMA1HntwqnOV3JLaEnTQ==",
       "dependencies": {
-        "@sentry/types": "7.108.0"
+        "@sentry/types": "7.118.0"
       },
       "engines": {
         "node": ">=8"
@@ -813,6 +828,11 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+    },
     "node_modules/import-local": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.1.0.tgz",
@@ -939,6 +959,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
     "node_modules/loader-runner": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
@@ -946,6 +974,14 @@
       "dev": true,
       "engines": {
         "node": ">=6.11.5"
+      }
+    },
+    "node_modules/localforage": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+      "dependencies": {
+        "lie": "3.1.1"
       }
     },
     "node_modules/locate-path": {
@@ -1638,81 +1674,93 @@
       }
     },
     "@sentry-internal/feedback": {
-      "version": "7.108.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.108.0.tgz",
-      "integrity": "sha512-8JcgZEnk1uWrXJhsd3iRvFtEiVeaWOEhN0NZwhwQXHfvODqep6JtrkY1yCIyxbpA37aZmrPc2JhyotRERGfUjg==",
+      "version": "7.118.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.118.0.tgz",
+      "integrity": "sha512-IYOGRcqIqKJJpMwBBv+0JTu0FPpXnakJYvOx/XEa/SNyF5+l7b9gGEjUVWh1ok50kTLW/XPnpnXNAGQcoKHg+w==",
       "requires": {
-        "@sentry/core": "7.108.0",
-        "@sentry/types": "7.108.0",
-        "@sentry/utils": "7.108.0"
+        "@sentry/core": "7.118.0",
+        "@sentry/types": "7.118.0",
+        "@sentry/utils": "7.118.0"
       }
     },
     "@sentry-internal/replay-canvas": {
-      "version": "7.108.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.108.0.tgz",
-      "integrity": "sha512-R5tvjGqWUV5vSk0N1eBgVW7wIADinrkfDEBZ9FyKP2mXHBobsyNGt30heJDEqYmVqluRqjU2NuIRapsnnrpGnA==",
+      "version": "7.118.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.118.0.tgz",
+      "integrity": "sha512-XxHlCClvrxmVKpiZetFYyiBaPQNiojoBGFFVgbbWBIAPc+fWeLJ2BMoQEBjn/0NA/8u8T6lErK5YQo/eIx9+XQ==",
       "requires": {
-        "@sentry/core": "7.108.0",
-        "@sentry/replay": "7.108.0",
-        "@sentry/types": "7.108.0",
-        "@sentry/utils": "7.108.0"
+        "@sentry/core": "7.118.0",
+        "@sentry/replay": "7.118.0",
+        "@sentry/types": "7.118.0",
+        "@sentry/utils": "7.118.0"
       }
     },
     "@sentry-internal/tracing": {
-      "version": "7.108.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.108.0.tgz",
-      "integrity": "sha512-zuK5XsTsb+U+hgn3SPetYDAogrXsM16U/LLoMW7+TlC6UjlHGYQvmX3o+M2vntejoU1QZS8m1bCAZSMWEypAEw==",
+      "version": "7.118.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.118.0.tgz",
+      "integrity": "sha512-dERAshKlQLrBscHSarhHyUeGsu652bDTUN1FK0m4e3X48M3I5/s+0N880Qjpe5MprNLcINlaIgdQ9jkisvxjfw==",
       "requires": {
-        "@sentry/core": "7.108.0",
-        "@sentry/types": "7.108.0",
-        "@sentry/utils": "7.108.0"
+        "@sentry/core": "7.118.0",
+        "@sentry/types": "7.118.0",
+        "@sentry/utils": "7.118.0"
       }
     },
     "@sentry/browser": {
-      "version": "7.108.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.108.0.tgz",
-      "integrity": "sha512-FNpzsdTvGvdHJMUelqEouUXMZU7jC+dpN7CdT6IoHVVFEkoAgrjMVUhXZoQ/dmCkdKWHmFSQhJ8Fm6V+e9Aq0A==",
+      "version": "7.118.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.118.0.tgz",
+      "integrity": "sha512-8onDOFV1VLEoBuqA5yaJeR3FF1JNuxr5C7p1oN3OwY724iTVqQnOLmZKZaSnHV3RkY67wKDGQkQIie14sc+42g==",
       "requires": {
-        "@sentry-internal/feedback": "7.108.0",
-        "@sentry-internal/replay-canvas": "7.108.0",
-        "@sentry-internal/tracing": "7.108.0",
-        "@sentry/core": "7.108.0",
-        "@sentry/replay": "7.108.0",
-        "@sentry/types": "7.108.0",
-        "@sentry/utils": "7.108.0"
+        "@sentry-internal/feedback": "7.118.0",
+        "@sentry-internal/replay-canvas": "7.118.0",
+        "@sentry-internal/tracing": "7.118.0",
+        "@sentry/core": "7.118.0",
+        "@sentry/integrations": "7.118.0",
+        "@sentry/replay": "7.118.0",
+        "@sentry/types": "7.118.0",
+        "@sentry/utils": "7.118.0"
       }
     },
     "@sentry/core": {
-      "version": "7.108.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.108.0.tgz",
-      "integrity": "sha512-I/VNZCFgLASxHZaD0EtxZRM34WG9w2gozqgrKGNMzAymwmQ3K9g/1qmBy4e6iS3YRptb7J5UhQkZQHrcwBbjWQ==",
+      "version": "7.118.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.118.0.tgz",
+      "integrity": "sha512-ol0xBdp3/K11IMAYSQE0FMxBOOH9hMsb/rjxXWe0hfM5c72CqYWL3ol7voPci0GELJ5CZG+9ImEU1V9r6gK64g==",
       "requires": {
-        "@sentry/types": "7.108.0",
-        "@sentry/utils": "7.108.0"
+        "@sentry/types": "7.118.0",
+        "@sentry/utils": "7.118.0"
+      }
+    },
+    "@sentry/integrations": {
+      "version": "7.118.0",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.118.0.tgz",
+      "integrity": "sha512-C2rR4NvIMjokF8jP5qzSf1o2zxDx7IeYnr8u15Kb2+HdZtX559owALR0hfgwnfeElqMhGlJBaKUWZ48lXJMzCQ==",
+      "requires": {
+        "@sentry/core": "7.118.0",
+        "@sentry/types": "7.118.0",
+        "@sentry/utils": "7.118.0",
+        "localforage": "^1.8.1"
       }
     },
     "@sentry/replay": {
-      "version": "7.108.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.108.0.tgz",
-      "integrity": "sha512-jo8fDOzcZJclP1+4n9jUtVxTlBFT9hXwxhAMrhrt70FV/nfmCtYQMD3bzIj79nwbhUtFP6pN39JH1o7Xqt1hxQ==",
+      "version": "7.118.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.118.0.tgz",
+      "integrity": "sha512-boQfCL+1L/tSZ9Huwi00+VtU+Ih1Lcg8HtxBuAsBCJR9pQgUL5jp7ECYdTeeHyCh/RJO7JqV1CEoGTgohe10mA==",
       "requires": {
-        "@sentry-internal/tracing": "7.108.0",
-        "@sentry/core": "7.108.0",
-        "@sentry/types": "7.108.0",
-        "@sentry/utils": "7.108.0"
+        "@sentry-internal/tracing": "7.118.0",
+        "@sentry/core": "7.118.0",
+        "@sentry/types": "7.118.0",
+        "@sentry/utils": "7.118.0"
       }
     },
     "@sentry/types": {
-      "version": "7.108.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.108.0.tgz",
-      "integrity": "sha512-bKtHITmBN3kqtqE5eVvL8mY8znM05vEodENwRpcm6TSrrBjC2RnwNWVwGstYDdHpNfFuKwC8mLY9bgMJcENo8g=="
+      "version": "7.118.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.118.0.tgz",
+      "integrity": "sha512-2drqrD2+6kgeg+W/ycmiti3G4lJrV3hGjY9PpJ3bJeXrh6T2+LxKPzlgSEnKFaeQWkXdZ4eaUbtTXVebMjb5JA=="
     },
     "@sentry/utils": {
-      "version": "7.108.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.108.0.tgz",
-      "integrity": "sha512-a45yEFD5qtgZaIFRAcFkG8C8lnDzn6t4LfLXuV4OafGAy/3ZAN3XN8wDnrruHkiUezSSANGsLg3bXaLW/JLvJw==",
+      "version": "7.118.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.118.0.tgz",
+      "integrity": "sha512-43qItc/ydxZV1Zb3Kn2M54RwL9XXFa3IAYBO8S82Qvq5YUYmU2AmJ1jgg7DabXlVSWgMA1HntwqnOV3JLaEnTQ==",
       "requires": {
-        "@sentry/types": "7.108.0"
+        "@sentry/types": "7.118.0"
       }
     },
     "@types/eslint": {
@@ -2170,6 +2218,11 @@
         "function-bind": "^1.1.1"
       }
     },
+    "immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+    },
     "import-local": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.1.0.tgz",
@@ -2262,11 +2315,27 @@
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
     },
+    "lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+      "requires": {
+        "immediate": "~3.0.5"
+      }
+    },
     "loader-runner": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
       "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
       "dev": true
+    },
+    "localforage": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+      "requires": {
+        "lie": "3.1.1"
+      }
     },
     "locate-path": {
       "version": "5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nextcloud_sentry",
-  "version": "8.12.0",
+  "version": "8.12.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nextcloud_sentry",
-  "version": "8.11.0",
+  "version": "8.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "nextcloud_sentry",
-      "version": "8.11.0",
+      "version": "8.12.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.4.0",
@@ -261,26 +261,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@types/eslint": {
-      "version": "8.4.10",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.10.tgz",
-      "integrity": "sha512-Sl/HOqN8NKPmhWo2VBEPm0nvHnu2LL3v9vKo8MEq0EtbJ4eVzGPl41VNPvn5E1i5poMk4/XD8UriLHpJvEP/Nw==",
-      "dev": true,
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
-    },
-    "node_modules/@types/eslint-scope": {
-      "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.4.tgz",
-      "integrity": "sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==",
-      "dev": true,
-      "dependencies": {
-        "@types/eslint": "*",
-        "@types/estree": "*"
       }
     },
     "node_modules/@types/estree": {
@@ -678,9 +658,9 @@
       "dev": true
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.17.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.0.tgz",
-      "integrity": "sha512-dwDPwZL0dmye8Txp2gzFmA6sxALaSvdRDjPH0viLcKrtlOL3tw62nWWweVD1SdILDTJrbrL6tdWVN58Wo6U3eA==",
+      "version": "5.17.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
+      "integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
       "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -1442,12 +1422,11 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.93.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.93.0.tgz",
-      "integrity": "sha512-Y0m5oEY1LRuwly578VqluorkXbvXKh7U3rLoQCEO04M97ScRr44afGVkI0FQFsXzysk5OgFAxjZAb9rsGQVihA==",
+      "version": "5.94.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.94.0.tgz",
+      "integrity": "sha512-KcsGn50VT+06JH/iunZJedYGUJS5FGjow8wb9c0v5n1Om8O1g4L6LjtfxwlXIATopoQu+vOXXa7gYisWxCoPyg==",
       "dev": true,
       "dependencies": {
-        "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^1.0.5",
         "@webassemblyjs/ast": "^1.12.1",
         "@webassemblyjs/wasm-edit": "^1.12.1",
@@ -1456,7 +1435,7 @@
         "acorn-import-attributes": "^1.9.5",
         "browserslist": "^4.21.10",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.17.0",
+        "enhanced-resolve": "^5.17.1",
         "es-module-lexer": "^1.2.1",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
@@ -1786,26 +1765,6 @@
         "@sentry/types": "7.119.1"
       }
     },
-    "@types/eslint": {
-      "version": "8.4.10",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.10.tgz",
-      "integrity": "sha512-Sl/HOqN8NKPmhWo2VBEPm0nvHnu2LL3v9vKo8MEq0EtbJ4eVzGPl41VNPvn5E1i5poMk4/XD8UriLHpJvEP/Nw==",
-      "dev": true,
-      "requires": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
-    },
-    "@types/eslint-scope": {
-      "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.4.tgz",
-      "integrity": "sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==",
-      "dev": true,
-      "requires": {
-        "@types/eslint": "*",
-        "@types/estree": "*"
-      }
-    },
     "@types/estree": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
@@ -2116,9 +2075,9 @@
       "dev": true
     },
     "enhanced-resolve": {
-      "version": "5.17.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.0.tgz",
-      "integrity": "sha512-dwDPwZL0dmye8Txp2gzFmA6sxALaSvdRDjPH0viLcKrtlOL3tw62nWWweVD1SdILDTJrbrL6tdWVN58Wo6U3eA==",
+      "version": "5.17.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
+      "integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.2.4",
@@ -2660,12 +2619,11 @@
       }
     },
     "webpack": {
-      "version": "5.93.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.93.0.tgz",
-      "integrity": "sha512-Y0m5oEY1LRuwly578VqluorkXbvXKh7U3rLoQCEO04M97ScRr44afGVkI0FQFsXzysk5OgFAxjZAb9rsGQVihA==",
+      "version": "5.94.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.94.0.tgz",
+      "integrity": "sha512-KcsGn50VT+06JH/iunZJedYGUJS5FGjow8wb9c0v5n1Om8O1g4L6LjtfxwlXIATopoQu+vOXXa7gYisWxCoPyg==",
       "dev": true,
       "requires": {
-        "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^1.0.5",
         "@webassemblyjs/ast": "^1.12.1",
         "@webassemblyjs/wasm-edit": "^1.12.1",
@@ -2674,7 +2632,7 @@
         "acorn-import-attributes": "^1.9.5",
         "browserslist": "^4.21.10",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.17.0",
+        "enhanced-resolve": "^5.17.1",
         "es-module-lexer": "^1.2.1",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "nextcloud_sentry",
-      "version": "8.9.8",
+      "version": "8.9.9",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.2.1",
@@ -15,7 +15,7 @@
         "@sentry/browser": "^7.108.0"
       },
       "devDependencies": {
-        "webpack": "^5.91.0",
+        "webpack": "^5.93.0",
         "webpack-cli": "^5.1.4",
         "webpack-merge": "^5.10.0"
       }
@@ -487,10 +487,10 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/acorn-import-assertions": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
-      "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
       "dev": true,
       "peerDependencies": {
         "acorn": "^8"
@@ -649,9 +649,9 @@
       "dev": true
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.16.0.tgz",
-      "integrity": "sha512-O+QWCviPNSSLAD9Ucn8Awv+poAkqn3T1XY5/N7kR7rQO9yfSGWkYZDwpJ+iKF7B8rxaQKWngSqACpgzeapSyoA==",
+      "version": "5.17.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.0.tgz",
+      "integrity": "sha512-dwDPwZL0dmye8Txp2gzFmA6sxALaSvdRDjPH0viLcKrtlOL3tw62nWWweVD1SdILDTJrbrL6tdWVN58Wo6U3eA==",
       "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -1401,9 +1401,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.91.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.91.0.tgz",
-      "integrity": "sha512-rzVwlLeBWHJbmgTC/8TvAcu5vpJNII+MelQpylD4jNERPwpBJOE2lEcko1zJX3QJeLjTTAnQxn/OJ8bjDzVQaw==",
+      "version": "5.93.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.93.0.tgz",
+      "integrity": "sha512-Y0m5oEY1LRuwly578VqluorkXbvXKh7U3rLoQCEO04M97ScRr44afGVkI0FQFsXzysk5OgFAxjZAb9rsGQVihA==",
       "dev": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
@@ -1412,10 +1412,10 @@
         "@webassemblyjs/wasm-edit": "^1.12.1",
         "@webassemblyjs/wasm-parser": "^1.12.1",
         "acorn": "^8.7.1",
-        "acorn-import-assertions": "^1.9.0",
+        "acorn-import-attributes": "^1.9.5",
         "browserslist": "^4.21.10",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.16.0",
+        "enhanced-resolve": "^5.17.0",
         "es-module-lexer": "^1.2.1",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
@@ -1938,10 +1938,10 @@
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
       "dev": true
     },
-    "acorn-import-assertions": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
-      "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
+    "acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
       "dev": true,
       "requires": {}
     },
@@ -2043,9 +2043,9 @@
       "dev": true
     },
     "enhanced-resolve": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.16.0.tgz",
-      "integrity": "sha512-O+QWCviPNSSLAD9Ucn8Awv+poAkqn3T1XY5/N7kR7rQO9yfSGWkYZDwpJ+iKF7B8rxaQKWngSqACpgzeapSyoA==",
+      "version": "5.17.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.0.tgz",
+      "integrity": "sha512-dwDPwZL0dmye8Txp2gzFmA6sxALaSvdRDjPH0viLcKrtlOL3tw62nWWweVD1SdILDTJrbrL6tdWVN58Wo6U3eA==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.2.4",
@@ -2572,9 +2572,9 @@
       }
     },
     "webpack": {
-      "version": "5.91.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.91.0.tgz",
-      "integrity": "sha512-rzVwlLeBWHJbmgTC/8TvAcu5vpJNII+MelQpylD4jNERPwpBJOE2lEcko1zJX3QJeLjTTAnQxn/OJ8bjDzVQaw==",
+      "version": "5.93.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.93.0.tgz",
+      "integrity": "sha512-Y0m5oEY1LRuwly578VqluorkXbvXKh7U3rLoQCEO04M97ScRr44afGVkI0FQFsXzysk5OgFAxjZAb9rsGQVihA==",
       "dev": true,
       "requires": {
         "@types/eslint-scope": "^3.7.3",
@@ -2583,10 +2583,10 @@
         "@webassemblyjs/wasm-edit": "^1.12.1",
         "@webassemblyjs/wasm-parser": "^1.12.1",
         "acorn": "^8.7.1",
-        "acorn-import-assertions": "^1.9.0",
+        "acorn-import-attributes": "^1.9.5",
         "browserslist": "^4.21.10",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.16.0",
+        "enhanced-resolve": "^5.17.0",
         "es-module-lexer": "^1.2.1",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "nextcloud_sentry",
-      "version": "8.10.0",
+      "version": "8.11.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.3.0",
@@ -134,83 +134,83 @@
       }
     },
     "node_modules/@sentry-internal/feedback": {
-      "version": "7.118.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.118.0.tgz",
-      "integrity": "sha512-IYOGRcqIqKJJpMwBBv+0JTu0FPpXnakJYvOx/XEa/SNyF5+l7b9gGEjUVWh1ok50kTLW/XPnpnXNAGQcoKHg+w==",
+      "version": "7.119.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.119.1.tgz",
+      "integrity": "sha512-EPyW6EKZmhKpw/OQUPRkTynXecZdYl4uhZwdZuGqnGMAzswPOgQvFrkwsOuPYvoMfXqCH7YuRqyJrox3uBOrTA==",
       "dependencies": {
-        "@sentry/core": "7.118.0",
-        "@sentry/types": "7.118.0",
-        "@sentry/utils": "7.118.0"
+        "@sentry/core": "7.119.1",
+        "@sentry/types": "7.119.1",
+        "@sentry/utils": "7.119.1"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@sentry-internal/replay-canvas": {
-      "version": "7.118.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.118.0.tgz",
-      "integrity": "sha512-XxHlCClvrxmVKpiZetFYyiBaPQNiojoBGFFVgbbWBIAPc+fWeLJ2BMoQEBjn/0NA/8u8T6lErK5YQo/eIx9+XQ==",
+      "version": "7.119.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.119.1.tgz",
+      "integrity": "sha512-O/lrzENbMhP/UDr7LwmfOWTjD9PLNmdaCF408Wx8SDuj7Iwc+VasGfHg7fPH4Pdr4nJON6oh+UqoV4IoG05u+A==",
       "dependencies": {
-        "@sentry/core": "7.118.0",
-        "@sentry/replay": "7.118.0",
-        "@sentry/types": "7.118.0",
-        "@sentry/utils": "7.118.0"
+        "@sentry/core": "7.119.1",
+        "@sentry/replay": "7.119.1",
+        "@sentry/types": "7.119.1",
+        "@sentry/utils": "7.119.1"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@sentry-internal/tracing": {
-      "version": "7.118.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.118.0.tgz",
-      "integrity": "sha512-dERAshKlQLrBscHSarhHyUeGsu652bDTUN1FK0m4e3X48M3I5/s+0N880Qjpe5MprNLcINlaIgdQ9jkisvxjfw==",
+      "version": "7.119.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.119.1.tgz",
+      "integrity": "sha512-cI0YraPd6qBwvUA3wQdPGTy8PzAoK0NZiaTN1LM3IczdPegehWOaEG5GVTnpGnTsmBAzn1xnBXNBhgiU4dgcrQ==",
       "dependencies": {
-        "@sentry/core": "7.118.0",
-        "@sentry/types": "7.118.0",
-        "@sentry/utils": "7.118.0"
+        "@sentry/core": "7.119.1",
+        "@sentry/types": "7.119.1",
+        "@sentry/utils": "7.119.1"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "7.118.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.118.0.tgz",
-      "integrity": "sha512-8onDOFV1VLEoBuqA5yaJeR3FF1JNuxr5C7p1oN3OwY724iTVqQnOLmZKZaSnHV3RkY67wKDGQkQIie14sc+42g==",
+      "version": "7.119.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.119.1.tgz",
+      "integrity": "sha512-aMwAnFU4iAPeLyZvqmOQaEDHt/Dkf8rpgYeJ0OEi50dmP6AjG+KIAMCXU7CYCCQDn70ITJo8QD5+KzCoZPYz0A==",
       "dependencies": {
-        "@sentry-internal/feedback": "7.118.0",
-        "@sentry-internal/replay-canvas": "7.118.0",
-        "@sentry-internal/tracing": "7.118.0",
-        "@sentry/core": "7.118.0",
-        "@sentry/integrations": "7.118.0",
-        "@sentry/replay": "7.118.0",
-        "@sentry/types": "7.118.0",
-        "@sentry/utils": "7.118.0"
+        "@sentry-internal/feedback": "7.119.1",
+        "@sentry-internal/replay-canvas": "7.119.1",
+        "@sentry-internal/tracing": "7.119.1",
+        "@sentry/core": "7.119.1",
+        "@sentry/integrations": "7.119.1",
+        "@sentry/replay": "7.119.1",
+        "@sentry/types": "7.119.1",
+        "@sentry/utils": "7.119.1"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/core": {
-      "version": "7.118.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.118.0.tgz",
-      "integrity": "sha512-ol0xBdp3/K11IMAYSQE0FMxBOOH9hMsb/rjxXWe0hfM5c72CqYWL3ol7voPci0GELJ5CZG+9ImEU1V9r6gK64g==",
+      "version": "7.119.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.119.1.tgz",
+      "integrity": "sha512-YUNnH7O7paVd+UmpArWCPH4Phlb5LwrkWVqzFWqL3xPyCcTSof2RL8UmvpkTjgYJjJ+NDfq5mPFkqv3aOEn5Sw==",
       "dependencies": {
-        "@sentry/types": "7.118.0",
-        "@sentry/utils": "7.118.0"
+        "@sentry/types": "7.119.1",
+        "@sentry/utils": "7.119.1"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/integrations": {
-      "version": "7.118.0",
-      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.118.0.tgz",
-      "integrity": "sha512-C2rR4NvIMjokF8jP5qzSf1o2zxDx7IeYnr8u15Kb2+HdZtX559owALR0hfgwnfeElqMhGlJBaKUWZ48lXJMzCQ==",
+      "version": "7.119.1",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.119.1.tgz",
+      "integrity": "sha512-CGmLEPnaBqbUleVqrmGYjRjf5/OwjUXo57I9t0KKWViq81mWnYhaUhRZWFNoCNQHns+3+GPCOMvl0zlawt+evw==",
       "dependencies": {
-        "@sentry/core": "7.118.0",
-        "@sentry/types": "7.118.0",
-        "@sentry/utils": "7.118.0",
+        "@sentry/core": "7.119.1",
+        "@sentry/types": "7.119.1",
+        "@sentry/utils": "7.119.1",
         "localforage": "^1.8.1"
       },
       "engines": {
@@ -218,33 +218,33 @@
       }
     },
     "node_modules/@sentry/replay": {
-      "version": "7.118.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.118.0.tgz",
-      "integrity": "sha512-boQfCL+1L/tSZ9Huwi00+VtU+Ih1Lcg8HtxBuAsBCJR9pQgUL5jp7ECYdTeeHyCh/RJO7JqV1CEoGTgohe10mA==",
+      "version": "7.119.1",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.119.1.tgz",
+      "integrity": "sha512-4da+ruMEipuAZf35Ybt2StBdV1S+oJbSVccGpnl9w6RoeQoloT4ztR6ML3UcFDTXeTPT1FnHWDCyOfST0O7XMw==",
       "dependencies": {
-        "@sentry-internal/tracing": "7.118.0",
-        "@sentry/core": "7.118.0",
-        "@sentry/types": "7.118.0",
-        "@sentry/utils": "7.118.0"
+        "@sentry-internal/tracing": "7.119.1",
+        "@sentry/core": "7.119.1",
+        "@sentry/types": "7.119.1",
+        "@sentry/utils": "7.119.1"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@sentry/types": {
-      "version": "7.118.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.118.0.tgz",
-      "integrity": "sha512-2drqrD2+6kgeg+W/ycmiti3G4lJrV3hGjY9PpJ3bJeXrh6T2+LxKPzlgSEnKFaeQWkXdZ4eaUbtTXVebMjb5JA==",
+      "version": "7.119.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.119.1.tgz",
+      "integrity": "sha512-4G2mcZNnYzK3pa2PuTq+M2GcwBRY/yy1rF+HfZU+LAPZr98nzq2X3+mJHNJoobeHRkvVh7YZMPi4ogXiIS5VNQ==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "7.118.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.118.0.tgz",
-      "integrity": "sha512-43qItc/ydxZV1Zb3Kn2M54RwL9XXFa3IAYBO8S82Qvq5YUYmU2AmJ1jgg7DabXlVSWgMA1HntwqnOV3JLaEnTQ==",
+      "version": "7.119.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.119.1.tgz",
+      "integrity": "sha512-ju/Cvyeu/vkfC5/XBV30UNet5kLEicZmXSyuLwZu95hEbL+foPdxN+re7pCI/eNqfe3B2vz7lvz5afLVOlQ2Hg==",
       "dependencies": {
-        "@sentry/types": "7.118.0"
+        "@sentry/types": "7.119.1"
       },
       "engines": {
         "node": ">=8"
@@ -1665,93 +1665,93 @@
       }
     },
     "@sentry-internal/feedback": {
-      "version": "7.118.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.118.0.tgz",
-      "integrity": "sha512-IYOGRcqIqKJJpMwBBv+0JTu0FPpXnakJYvOx/XEa/SNyF5+l7b9gGEjUVWh1ok50kTLW/XPnpnXNAGQcoKHg+w==",
+      "version": "7.119.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.119.1.tgz",
+      "integrity": "sha512-EPyW6EKZmhKpw/OQUPRkTynXecZdYl4uhZwdZuGqnGMAzswPOgQvFrkwsOuPYvoMfXqCH7YuRqyJrox3uBOrTA==",
       "requires": {
-        "@sentry/core": "7.118.0",
-        "@sentry/types": "7.118.0",
-        "@sentry/utils": "7.118.0"
+        "@sentry/core": "7.119.1",
+        "@sentry/types": "7.119.1",
+        "@sentry/utils": "7.119.1"
       }
     },
     "@sentry-internal/replay-canvas": {
-      "version": "7.118.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.118.0.tgz",
-      "integrity": "sha512-XxHlCClvrxmVKpiZetFYyiBaPQNiojoBGFFVgbbWBIAPc+fWeLJ2BMoQEBjn/0NA/8u8T6lErK5YQo/eIx9+XQ==",
+      "version": "7.119.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.119.1.tgz",
+      "integrity": "sha512-O/lrzENbMhP/UDr7LwmfOWTjD9PLNmdaCF408Wx8SDuj7Iwc+VasGfHg7fPH4Pdr4nJON6oh+UqoV4IoG05u+A==",
       "requires": {
-        "@sentry/core": "7.118.0",
-        "@sentry/replay": "7.118.0",
-        "@sentry/types": "7.118.0",
-        "@sentry/utils": "7.118.0"
+        "@sentry/core": "7.119.1",
+        "@sentry/replay": "7.119.1",
+        "@sentry/types": "7.119.1",
+        "@sentry/utils": "7.119.1"
       }
     },
     "@sentry-internal/tracing": {
-      "version": "7.118.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.118.0.tgz",
-      "integrity": "sha512-dERAshKlQLrBscHSarhHyUeGsu652bDTUN1FK0m4e3X48M3I5/s+0N880Qjpe5MprNLcINlaIgdQ9jkisvxjfw==",
+      "version": "7.119.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.119.1.tgz",
+      "integrity": "sha512-cI0YraPd6qBwvUA3wQdPGTy8PzAoK0NZiaTN1LM3IczdPegehWOaEG5GVTnpGnTsmBAzn1xnBXNBhgiU4dgcrQ==",
       "requires": {
-        "@sentry/core": "7.118.0",
-        "@sentry/types": "7.118.0",
-        "@sentry/utils": "7.118.0"
+        "@sentry/core": "7.119.1",
+        "@sentry/types": "7.119.1",
+        "@sentry/utils": "7.119.1"
       }
     },
     "@sentry/browser": {
-      "version": "7.118.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.118.0.tgz",
-      "integrity": "sha512-8onDOFV1VLEoBuqA5yaJeR3FF1JNuxr5C7p1oN3OwY724iTVqQnOLmZKZaSnHV3RkY67wKDGQkQIie14sc+42g==",
+      "version": "7.119.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.119.1.tgz",
+      "integrity": "sha512-aMwAnFU4iAPeLyZvqmOQaEDHt/Dkf8rpgYeJ0OEi50dmP6AjG+KIAMCXU7CYCCQDn70ITJo8QD5+KzCoZPYz0A==",
       "requires": {
-        "@sentry-internal/feedback": "7.118.0",
-        "@sentry-internal/replay-canvas": "7.118.0",
-        "@sentry-internal/tracing": "7.118.0",
-        "@sentry/core": "7.118.0",
-        "@sentry/integrations": "7.118.0",
-        "@sentry/replay": "7.118.0",
-        "@sentry/types": "7.118.0",
-        "@sentry/utils": "7.118.0"
+        "@sentry-internal/feedback": "7.119.1",
+        "@sentry-internal/replay-canvas": "7.119.1",
+        "@sentry-internal/tracing": "7.119.1",
+        "@sentry/core": "7.119.1",
+        "@sentry/integrations": "7.119.1",
+        "@sentry/replay": "7.119.1",
+        "@sentry/types": "7.119.1",
+        "@sentry/utils": "7.119.1"
       }
     },
     "@sentry/core": {
-      "version": "7.118.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.118.0.tgz",
-      "integrity": "sha512-ol0xBdp3/K11IMAYSQE0FMxBOOH9hMsb/rjxXWe0hfM5c72CqYWL3ol7voPci0GELJ5CZG+9ImEU1V9r6gK64g==",
+      "version": "7.119.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.119.1.tgz",
+      "integrity": "sha512-YUNnH7O7paVd+UmpArWCPH4Phlb5LwrkWVqzFWqL3xPyCcTSof2RL8UmvpkTjgYJjJ+NDfq5mPFkqv3aOEn5Sw==",
       "requires": {
-        "@sentry/types": "7.118.0",
-        "@sentry/utils": "7.118.0"
+        "@sentry/types": "7.119.1",
+        "@sentry/utils": "7.119.1"
       }
     },
     "@sentry/integrations": {
-      "version": "7.118.0",
-      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.118.0.tgz",
-      "integrity": "sha512-C2rR4NvIMjokF8jP5qzSf1o2zxDx7IeYnr8u15Kb2+HdZtX559owALR0hfgwnfeElqMhGlJBaKUWZ48lXJMzCQ==",
+      "version": "7.119.1",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.119.1.tgz",
+      "integrity": "sha512-CGmLEPnaBqbUleVqrmGYjRjf5/OwjUXo57I9t0KKWViq81mWnYhaUhRZWFNoCNQHns+3+GPCOMvl0zlawt+evw==",
       "requires": {
-        "@sentry/core": "7.118.0",
-        "@sentry/types": "7.118.0",
-        "@sentry/utils": "7.118.0",
+        "@sentry/core": "7.119.1",
+        "@sentry/types": "7.119.1",
+        "@sentry/utils": "7.119.1",
         "localforage": "^1.8.1"
       }
     },
     "@sentry/replay": {
-      "version": "7.118.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.118.0.tgz",
-      "integrity": "sha512-boQfCL+1L/tSZ9Huwi00+VtU+Ih1Lcg8HtxBuAsBCJR9pQgUL5jp7ECYdTeeHyCh/RJO7JqV1CEoGTgohe10mA==",
+      "version": "7.119.1",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.119.1.tgz",
+      "integrity": "sha512-4da+ruMEipuAZf35Ybt2StBdV1S+oJbSVccGpnl9w6RoeQoloT4ztR6ML3UcFDTXeTPT1FnHWDCyOfST0O7XMw==",
       "requires": {
-        "@sentry-internal/tracing": "7.118.0",
-        "@sentry/core": "7.118.0",
-        "@sentry/types": "7.118.0",
-        "@sentry/utils": "7.118.0"
+        "@sentry-internal/tracing": "7.119.1",
+        "@sentry/core": "7.119.1",
+        "@sentry/types": "7.119.1",
+        "@sentry/utils": "7.119.1"
       }
     },
     "@sentry/types": {
-      "version": "7.118.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.118.0.tgz",
-      "integrity": "sha512-2drqrD2+6kgeg+W/ycmiti3G4lJrV3hGjY9PpJ3bJeXrh6T2+LxKPzlgSEnKFaeQWkXdZ4eaUbtTXVebMjb5JA=="
+      "version": "7.119.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.119.1.tgz",
+      "integrity": "sha512-4G2mcZNnYzK3pa2PuTq+M2GcwBRY/yy1rF+HfZU+LAPZr98nzq2X3+mJHNJoobeHRkvVh7YZMPi4ogXiIS5VNQ=="
     },
     "@sentry/utils": {
-      "version": "7.118.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.118.0.tgz",
-      "integrity": "sha512-43qItc/ydxZV1Zb3Kn2M54RwL9XXFa3IAYBO8S82Qvq5YUYmU2AmJ1jgg7DabXlVSWgMA1HntwqnOV3JLaEnTQ==",
+      "version": "7.119.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.119.1.tgz",
+      "integrity": "sha512-ju/Cvyeu/vkfC5/XBV30UNet5kLEicZmXSyuLwZu95hEbL+foPdxN+re7pCI/eNqfe3B2vz7lvz5afLVOlQ2Hg==",
       "requires": {
-        "@sentry/types": "7.118.0"
+        "@sentry/types": "7.119.1"
       }
     },
     "@types/eslint": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@sentry/browser": "^7.119.2"
       },
       "devDependencies": {
-        "webpack": "^5.93.0",
+        "webpack": "^5.95.0",
         "webpack-cli": "^5.1.4",
         "webpack-merge": "^6.0.1"
       }
@@ -1422,9 +1422,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.94.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.94.0.tgz",
-      "integrity": "sha512-KcsGn50VT+06JH/iunZJedYGUJS5FGjow8wb9c0v5n1Om8O1g4L6LjtfxwlXIATopoQu+vOXXa7gYisWxCoPyg==",
+      "version": "5.95.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.95.0.tgz",
+      "integrity": "sha512-2t3XstrKULz41MNMBF+cJ97TyHdyQ8HCt//pqErqDvNjU9YQBnZxIHa11VXsi7F3mb5/aO2tuDxdeTPdU7xu9Q==",
       "dev": true,
       "dependencies": {
         "@types/estree": "^1.0.5",
@@ -2619,9 +2619,9 @@
       }
     },
     "webpack": {
-      "version": "5.94.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.94.0.tgz",
-      "integrity": "sha512-KcsGn50VT+06JH/iunZJedYGUJS5FGjow8wb9c0v5n1Om8O1g4L6LjtfxwlXIATopoQu+vOXXa7gYisWxCoPyg==",
+      "version": "5.95.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.95.0.tgz",
+      "integrity": "sha512-2t3XstrKULz41MNMBF+cJ97TyHdyQ8HCt//pqErqDvNjU9YQBnZxIHa11VXsi7F3mb5/aO2tuDxdeTPdU7xu9Q==",
       "dev": true,
       "requires": {
         "@types/estree": "^1.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "nextcloud_sentry",
-      "version": "8.12.0",
+      "version": "8.12.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.4.0",
@@ -15,7 +15,7 @@
         "@sentry/browser": "^7.119.2"
       },
       "devDependencies": {
-        "webpack": "^5.95.0",
+        "webpack": "^5.96.1",
         "webpack-cli": "^5.1.4",
         "webpack-merge": "^6.0.1"
       }
@@ -263,10 +263,30 @@
         "node": ">=8"
       }
     },
+    "node_modules/@types/eslint": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
+      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "node_modules/@types/eslint-scope": {
+      "version": "3.7.7",
+      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
+      "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
+      "dev": true,
+      "dependencies": {
+        "@types/eslint": "*",
+        "@types/estree": "*"
+      }
+    },
     "node_modules/@types/estree": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
       "dev": true
     },
     "node_modules/@types/json-schema": {
@@ -486,24 +506,15 @@
       "dev": true
     },
     "node_modules/acorn": {
-      "version": "8.11.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-import-attributes": {
-      "version": "1.9.5",
-      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
-      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
-      "dev": true,
-      "peerDependencies": {
-        "acorn": "^8"
       }
     },
     "node_modules/ajv": {
@@ -532,9 +543,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.22.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.3.tgz",
-      "integrity": "sha512-UAp55yfwNv0klWNapjs/ktHoguxuQNGnOzxYmfnXIS+8AsRDZkSDxg7R1AX3GKzn078SBI5dzwzj/Yx0Or0e3A==",
+      "version": "4.24.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.2.tgz",
+      "integrity": "sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==",
       "dev": true,
       "funding": [
         {
@@ -551,10 +562,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001580",
-        "electron-to-chromium": "^1.4.648",
-        "node-releases": "^2.0.14",
-        "update-browserslist-db": "^1.0.13"
+        "caniuse-lite": "^1.0.30001669",
+        "electron-to-chromium": "^1.5.41",
+        "node-releases": "^2.0.18",
+        "update-browserslist-db": "^1.1.1"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -570,9 +581,9 @@
       "dev": true
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001581",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001581.tgz",
-      "integrity": "sha512-whlTkwhqV2tUmP3oYhtNfaWGYHDdS3JYFQBKXxcUR9qqPWsRhFHhoISO2Xnl/g0xyKzht9mI1LZpiNWfMzHixQ==",
+      "version": "1.0.30001677",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001677.tgz",
+      "integrity": "sha512-fmfjsOlJUpMWu+mAAtZZZHz7UEwsUxIIvu1TJfO1HqFQvB/B+ii0xr9B5HpbZY/mC4XZ8SvjHJqtAY6pDPQEog==",
       "dev": true,
       "funding": [
         {
@@ -652,9 +663,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.648",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.648.tgz",
-      "integrity": "sha512-EmFMarXeqJp9cUKu/QEciEApn0S/xRcpZWuAm32U7NgoZCimjsilKXHRO9saeEW55eHZagIDg6XTUOv32w9pjg==",
+      "version": "1.5.50",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.50.tgz",
+      "integrity": "sha512-eMVObiUQ2LdgeO1F/ySTXsvqvxb6ZH2zPGaMYsWzRDdOddUa77tdmI0ltg+L16UpbWdhPmuF3wIQYyQq65WfZw==",
       "dev": true
     },
     "node_modules/enhanced-resolve": {
@@ -689,9 +700,9 @@
       "dev": true
     },
     "node_modules/escalade": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -1024,9 +1035,9 @@
       "dev": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
+      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
       "dev": true
     },
     "node_modules/p-limit": {
@@ -1090,9 +1101,9 @@
       "dev": true
     },
     "node_modules/picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true
     },
     "node_modules/pkg-dir": {
@@ -1370,9 +1381,9 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
-      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
+      "integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
       "dev": true,
       "funding": [
         {
@@ -1389,8 +1400,8 @@
         }
       ],
       "dependencies": {
-        "escalade": "^3.1.1",
-        "picocolors": "^1.0.0"
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.0"
       },
       "bin": {
         "update-browserslist-db": "cli.js"
@@ -1422,18 +1433,18 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.95.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.95.0.tgz",
-      "integrity": "sha512-2t3XstrKULz41MNMBF+cJ97TyHdyQ8HCt//pqErqDvNjU9YQBnZxIHa11VXsi7F3mb5/aO2tuDxdeTPdU7xu9Q==",
+      "version": "5.96.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.96.1.tgz",
+      "integrity": "sha512-l2LlBSvVZGhL4ZrPwyr8+37AunkcYj5qh8o6u2/2rzoPc8gxFJkLj1WxNgooi9pnoc06jh0BjuXnamM4qlujZA==",
       "dev": true,
       "dependencies": {
-        "@types/estree": "^1.0.5",
+        "@types/eslint-scope": "^3.7.7",
+        "@types/estree": "^1.0.6",
         "@webassemblyjs/ast": "^1.12.1",
         "@webassemblyjs/wasm-edit": "^1.12.1",
         "@webassemblyjs/wasm-parser": "^1.12.1",
-        "acorn": "^8.7.1",
-        "acorn-import-attributes": "^1.9.5",
-        "browserslist": "^4.21.10",
+        "acorn": "^8.14.0",
+        "browserslist": "^4.24.0",
         "chrome-trace-event": "^1.0.2",
         "enhanced-resolve": "^5.17.1",
         "es-module-lexer": "^1.2.1",
@@ -1765,10 +1776,30 @@
         "@sentry/types": "7.119.2"
       }
     },
+    "@types/eslint": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
+      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "@types/eslint-scope": {
+      "version": "3.7.7",
+      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
+      "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
+      "dev": true,
+      "requires": {
+        "@types/eslint": "*",
+        "@types/estree": "*"
+      }
+    },
     "@types/estree": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
       "dev": true
     },
     "@types/json-schema": {
@@ -1965,17 +1996,10 @@
       "dev": true
     },
     "acorn": {
-      "version": "8.11.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true
-    },
-    "acorn-import-attributes": {
-      "version": "1.9.5",
-      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
-      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
-      "dev": true,
-      "requires": {}
     },
     "ajv": {
       "version": "6.12.6",
@@ -1997,15 +2021,15 @@
       "requires": {}
     },
     "browserslist": {
-      "version": "4.22.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.3.tgz",
-      "integrity": "sha512-UAp55yfwNv0klWNapjs/ktHoguxuQNGnOzxYmfnXIS+8AsRDZkSDxg7R1AX3GKzn078SBI5dzwzj/Yx0Or0e3A==",
+      "version": "4.24.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.2.tgz",
+      "integrity": "sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001580",
-        "electron-to-chromium": "^1.4.648",
-        "node-releases": "^2.0.14",
-        "update-browserslist-db": "^1.0.13"
+        "caniuse-lite": "^1.0.30001669",
+        "electron-to-chromium": "^1.5.41",
+        "node-releases": "^2.0.18",
+        "update-browserslist-db": "^1.1.1"
       }
     },
     "buffer-from": {
@@ -2015,9 +2039,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001581",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001581.tgz",
-      "integrity": "sha512-whlTkwhqV2tUmP3oYhtNfaWGYHDdS3JYFQBKXxcUR9qqPWsRhFHhoISO2Xnl/g0xyKzht9mI1LZpiNWfMzHixQ==",
+      "version": "1.0.30001677",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001677.tgz",
+      "integrity": "sha512-fmfjsOlJUpMWu+mAAtZZZHz7UEwsUxIIvu1TJfO1HqFQvB/B+ii0xr9B5HpbZY/mC4XZ8SvjHJqtAY6pDPQEog==",
       "dev": true
     },
     "chrome-trace-event": {
@@ -2069,9 +2093,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.648",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.648.tgz",
-      "integrity": "sha512-EmFMarXeqJp9cUKu/QEciEApn0S/xRcpZWuAm32U7NgoZCimjsilKXHRO9saeEW55eHZagIDg6XTUOv32w9pjg==",
+      "version": "1.5.50",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.50.tgz",
+      "integrity": "sha512-eMVObiUQ2LdgeO1F/ySTXsvqvxb6ZH2zPGaMYsWzRDdOddUa77tdmI0ltg+L16UpbWdhPmuF3wIQYyQq65WfZw==",
       "dev": true
     },
     "enhanced-resolve": {
@@ -2097,9 +2121,9 @@
       "dev": true
     },
     "escalade": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true
     },
     "eslint-scope": {
@@ -2358,9 +2382,9 @@
       "dev": true
     },
     "node-releases": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
+      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
       "dev": true
     },
     "p-limit": {
@@ -2406,9 +2430,9 @@
       "dev": true
     },
     "picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true
     },
     "pkg-dir": {
@@ -2590,13 +2614,13 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "update-browserslist-db": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
-      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
+      "integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
       "dev": true,
       "requires": {
-        "escalade": "^3.1.1",
-        "picocolors": "^1.0.0"
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.0"
       }
     },
     "uri-js": {
@@ -2619,18 +2643,18 @@
       }
     },
     "webpack": {
-      "version": "5.95.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.95.0.tgz",
-      "integrity": "sha512-2t3XstrKULz41MNMBF+cJ97TyHdyQ8HCt//pqErqDvNjU9YQBnZxIHa11VXsi7F3mb5/aO2tuDxdeTPdU7xu9Q==",
+      "version": "5.96.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.96.1.tgz",
+      "integrity": "sha512-l2LlBSvVZGhL4ZrPwyr8+37AunkcYj5qh8o6u2/2rzoPc8gxFJkLj1WxNgooi9pnoc06jh0BjuXnamM4qlujZA==",
       "dev": true,
       "requires": {
-        "@types/estree": "^1.0.5",
+        "@types/eslint-scope": "^3.7.7",
+        "@types/estree": "^1.0.6",
         "@webassemblyjs/ast": "^1.12.1",
         "@webassemblyjs/wasm-edit": "^1.12.1",
         "@webassemblyjs/wasm-parser": "^1.12.1",
-        "acorn": "^8.7.1",
-        "acorn-import-attributes": "^1.9.5",
-        "browserslist": "^4.21.10",
+        "acorn": "^8.14.0",
+        "browserslist": "^4.24.0",
         "chrome-trace-event": "^1.0.2",
         "enhanced-resolve": "^5.17.1",
         "es-module-lexer": "^1.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@nextcloud/auth": "^2.4.0",
         "@nextcloud/initial-state": "^2.2.0",
         "@nextcloud/logger": "^3.0.2",
-        "@sentry/browser": "^7.118.0"
+        "@sentry/browser": "^7.119.2"
       },
       "devDependencies": {
         "webpack": "^5.93.0",
@@ -147,83 +147,83 @@
       }
     },
     "node_modules/@sentry-internal/feedback": {
-      "version": "7.119.1",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.119.1.tgz",
-      "integrity": "sha512-EPyW6EKZmhKpw/OQUPRkTynXecZdYl4uhZwdZuGqnGMAzswPOgQvFrkwsOuPYvoMfXqCH7YuRqyJrox3uBOrTA==",
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.119.2.tgz",
+      "integrity": "sha512-bnR1yJWVBZfXGx675nMXE8hCXsxluCBfIFy9GQT8PTN/urxpoS9cGz+5F7MA7Xe3Q06/7TT0Mz3fcDvjkqTu3Q==",
       "dependencies": {
-        "@sentry/core": "7.119.1",
-        "@sentry/types": "7.119.1",
-        "@sentry/utils": "7.119.1"
+        "@sentry/core": "7.119.2",
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@sentry-internal/replay-canvas": {
-      "version": "7.119.1",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.119.1.tgz",
-      "integrity": "sha512-O/lrzENbMhP/UDr7LwmfOWTjD9PLNmdaCF408Wx8SDuj7Iwc+VasGfHg7fPH4Pdr4nJON6oh+UqoV4IoG05u+A==",
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.119.2.tgz",
+      "integrity": "sha512-Lqo8IFyeKkdOrOGRqm9jCEqeBl8kINe5+c2VqULpkO/I6ql6ISwPSYnmG6yL8cCVIaT1893CLog/pS4FxCv8/Q==",
       "dependencies": {
-        "@sentry/core": "7.119.1",
-        "@sentry/replay": "7.119.1",
-        "@sentry/types": "7.119.1",
-        "@sentry/utils": "7.119.1"
+        "@sentry/core": "7.119.2",
+        "@sentry/replay": "7.119.2",
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@sentry-internal/tracing": {
-      "version": "7.119.1",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.119.1.tgz",
-      "integrity": "sha512-cI0YraPd6qBwvUA3wQdPGTy8PzAoK0NZiaTN1LM3IczdPegehWOaEG5GVTnpGnTsmBAzn1xnBXNBhgiU4dgcrQ==",
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.119.2.tgz",
+      "integrity": "sha512-V2W+STWrafyGJhQv3ulMFXYDwWHiU6wHQAQBShsHVACiFaDrJ2kPRet38FKv4dMLlLlP2xN+ss2e5zv3tYlTiQ==",
       "dependencies": {
-        "@sentry/core": "7.119.1",
-        "@sentry/types": "7.119.1",
-        "@sentry/utils": "7.119.1"
+        "@sentry/core": "7.119.2",
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "7.119.1",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.119.1.tgz",
-      "integrity": "sha512-aMwAnFU4iAPeLyZvqmOQaEDHt/Dkf8rpgYeJ0OEi50dmP6AjG+KIAMCXU7CYCCQDn70ITJo8QD5+KzCoZPYz0A==",
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.119.2.tgz",
+      "integrity": "sha512-Wb2RzCsJBTNCmS9KPmbVyV5GGzFXjFdUThAN9xlnN5GgemMBwdQjGu/tRYr8yJAVsRb0EOFH8IuJBNKKNnO49g==",
       "dependencies": {
-        "@sentry-internal/feedback": "7.119.1",
-        "@sentry-internal/replay-canvas": "7.119.1",
-        "@sentry-internal/tracing": "7.119.1",
-        "@sentry/core": "7.119.1",
-        "@sentry/integrations": "7.119.1",
-        "@sentry/replay": "7.119.1",
-        "@sentry/types": "7.119.1",
-        "@sentry/utils": "7.119.1"
+        "@sentry-internal/feedback": "7.119.2",
+        "@sentry-internal/replay-canvas": "7.119.2",
+        "@sentry-internal/tracing": "7.119.2",
+        "@sentry/core": "7.119.2",
+        "@sentry/integrations": "7.119.2",
+        "@sentry/replay": "7.119.2",
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/core": {
-      "version": "7.119.1",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.119.1.tgz",
-      "integrity": "sha512-YUNnH7O7paVd+UmpArWCPH4Phlb5LwrkWVqzFWqL3xPyCcTSof2RL8UmvpkTjgYJjJ+NDfq5mPFkqv3aOEn5Sw==",
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.119.2.tgz",
+      "integrity": "sha512-hQr3d2yWq/2lMvoyBPOwXw1IHqTrCjOsU1vYKhAa6w9vGbJZFGhKGGE2KEi/92c3gqGn+gW/PC7cV6waCTDuVA==",
       "dependencies": {
-        "@sentry/types": "7.119.1",
-        "@sentry/utils": "7.119.1"
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/integrations": {
-      "version": "7.119.1",
-      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.119.1.tgz",
-      "integrity": "sha512-CGmLEPnaBqbUleVqrmGYjRjf5/OwjUXo57I9t0KKWViq81mWnYhaUhRZWFNoCNQHns+3+GPCOMvl0zlawt+evw==",
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.119.2.tgz",
+      "integrity": "sha512-dCuXKvbUE3gXVVa696SYMjlhSP6CxpMH/gl4Jk26naEB8Xjsn98z/hqEoXLg6Nab73rjR9c/9AdKqBbwVMHyrQ==",
       "dependencies": {
-        "@sentry/core": "7.119.1",
-        "@sentry/types": "7.119.1",
-        "@sentry/utils": "7.119.1",
+        "@sentry/core": "7.119.2",
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2",
         "localforage": "^1.8.1"
       },
       "engines": {
@@ -231,33 +231,33 @@
       }
     },
     "node_modules/@sentry/replay": {
-      "version": "7.119.1",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.119.1.tgz",
-      "integrity": "sha512-4da+ruMEipuAZf35Ybt2StBdV1S+oJbSVccGpnl9w6RoeQoloT4ztR6ML3UcFDTXeTPT1FnHWDCyOfST0O7XMw==",
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.119.2.tgz",
+      "integrity": "sha512-nHDsBt0mlJXTWAHjzQdCzDbhV2fv8B62PPB5mu5SpI+G5h+ir3r5lR0lZZrMT8eurVowb/HnLXAs+XYVug3blg==",
       "dependencies": {
-        "@sentry-internal/tracing": "7.119.1",
-        "@sentry/core": "7.119.1",
-        "@sentry/types": "7.119.1",
-        "@sentry/utils": "7.119.1"
+        "@sentry-internal/tracing": "7.119.2",
+        "@sentry/core": "7.119.2",
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@sentry/types": {
-      "version": "7.119.1",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.119.1.tgz",
-      "integrity": "sha512-4G2mcZNnYzK3pa2PuTq+M2GcwBRY/yy1rF+HfZU+LAPZr98nzq2X3+mJHNJoobeHRkvVh7YZMPi4ogXiIS5VNQ==",
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.119.2.tgz",
+      "integrity": "sha512-ydq1tWsdG7QW+yFaTp0gFaowMLNVikIqM70wxWNK+u98QzKnVY/3XTixxNLsUtnAB4Y+isAzFhrc6Vb5GFdFeg==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "7.119.1",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.119.1.tgz",
-      "integrity": "sha512-ju/Cvyeu/vkfC5/XBV30UNet5kLEicZmXSyuLwZu95hEbL+foPdxN+re7pCI/eNqfe3B2vz7lvz5afLVOlQ2Hg==",
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.119.2.tgz",
+      "integrity": "sha512-TLdUCvcNgzKP0r9YD7tgCL1PEUp42TObISridsPJ5rhpVGQJvpr+Six0zIkfDUxerLYWZoK8QMm9KgFlPLNQzA==",
       "dependencies": {
-        "@sentry/types": "7.119.1"
+        "@sentry/types": "7.119.2"
       },
       "engines": {
         "node": ">=8"
@@ -1676,93 +1676,93 @@
       }
     },
     "@sentry-internal/feedback": {
-      "version": "7.119.1",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.119.1.tgz",
-      "integrity": "sha512-EPyW6EKZmhKpw/OQUPRkTynXecZdYl4uhZwdZuGqnGMAzswPOgQvFrkwsOuPYvoMfXqCH7YuRqyJrox3uBOrTA==",
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.119.2.tgz",
+      "integrity": "sha512-bnR1yJWVBZfXGx675nMXE8hCXsxluCBfIFy9GQT8PTN/urxpoS9cGz+5F7MA7Xe3Q06/7TT0Mz3fcDvjkqTu3Q==",
       "requires": {
-        "@sentry/core": "7.119.1",
-        "@sentry/types": "7.119.1",
-        "@sentry/utils": "7.119.1"
+        "@sentry/core": "7.119.2",
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2"
       }
     },
     "@sentry-internal/replay-canvas": {
-      "version": "7.119.1",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.119.1.tgz",
-      "integrity": "sha512-O/lrzENbMhP/UDr7LwmfOWTjD9PLNmdaCF408Wx8SDuj7Iwc+VasGfHg7fPH4Pdr4nJON6oh+UqoV4IoG05u+A==",
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.119.2.tgz",
+      "integrity": "sha512-Lqo8IFyeKkdOrOGRqm9jCEqeBl8kINe5+c2VqULpkO/I6ql6ISwPSYnmG6yL8cCVIaT1893CLog/pS4FxCv8/Q==",
       "requires": {
-        "@sentry/core": "7.119.1",
-        "@sentry/replay": "7.119.1",
-        "@sentry/types": "7.119.1",
-        "@sentry/utils": "7.119.1"
+        "@sentry/core": "7.119.2",
+        "@sentry/replay": "7.119.2",
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2"
       }
     },
     "@sentry-internal/tracing": {
-      "version": "7.119.1",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.119.1.tgz",
-      "integrity": "sha512-cI0YraPd6qBwvUA3wQdPGTy8PzAoK0NZiaTN1LM3IczdPegehWOaEG5GVTnpGnTsmBAzn1xnBXNBhgiU4dgcrQ==",
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.119.2.tgz",
+      "integrity": "sha512-V2W+STWrafyGJhQv3ulMFXYDwWHiU6wHQAQBShsHVACiFaDrJ2kPRet38FKv4dMLlLlP2xN+ss2e5zv3tYlTiQ==",
       "requires": {
-        "@sentry/core": "7.119.1",
-        "@sentry/types": "7.119.1",
-        "@sentry/utils": "7.119.1"
+        "@sentry/core": "7.119.2",
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2"
       }
     },
     "@sentry/browser": {
-      "version": "7.119.1",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.119.1.tgz",
-      "integrity": "sha512-aMwAnFU4iAPeLyZvqmOQaEDHt/Dkf8rpgYeJ0OEi50dmP6AjG+KIAMCXU7CYCCQDn70ITJo8QD5+KzCoZPYz0A==",
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.119.2.tgz",
+      "integrity": "sha512-Wb2RzCsJBTNCmS9KPmbVyV5GGzFXjFdUThAN9xlnN5GgemMBwdQjGu/tRYr8yJAVsRb0EOFH8IuJBNKKNnO49g==",
       "requires": {
-        "@sentry-internal/feedback": "7.119.1",
-        "@sentry-internal/replay-canvas": "7.119.1",
-        "@sentry-internal/tracing": "7.119.1",
-        "@sentry/core": "7.119.1",
-        "@sentry/integrations": "7.119.1",
-        "@sentry/replay": "7.119.1",
-        "@sentry/types": "7.119.1",
-        "@sentry/utils": "7.119.1"
+        "@sentry-internal/feedback": "7.119.2",
+        "@sentry-internal/replay-canvas": "7.119.2",
+        "@sentry-internal/tracing": "7.119.2",
+        "@sentry/core": "7.119.2",
+        "@sentry/integrations": "7.119.2",
+        "@sentry/replay": "7.119.2",
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2"
       }
     },
     "@sentry/core": {
-      "version": "7.119.1",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.119.1.tgz",
-      "integrity": "sha512-YUNnH7O7paVd+UmpArWCPH4Phlb5LwrkWVqzFWqL3xPyCcTSof2RL8UmvpkTjgYJjJ+NDfq5mPFkqv3aOEn5Sw==",
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.119.2.tgz",
+      "integrity": "sha512-hQr3d2yWq/2lMvoyBPOwXw1IHqTrCjOsU1vYKhAa6w9vGbJZFGhKGGE2KEi/92c3gqGn+gW/PC7cV6waCTDuVA==",
       "requires": {
-        "@sentry/types": "7.119.1",
-        "@sentry/utils": "7.119.1"
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2"
       }
     },
     "@sentry/integrations": {
-      "version": "7.119.1",
-      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.119.1.tgz",
-      "integrity": "sha512-CGmLEPnaBqbUleVqrmGYjRjf5/OwjUXo57I9t0KKWViq81mWnYhaUhRZWFNoCNQHns+3+GPCOMvl0zlawt+evw==",
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.119.2.tgz",
+      "integrity": "sha512-dCuXKvbUE3gXVVa696SYMjlhSP6CxpMH/gl4Jk26naEB8Xjsn98z/hqEoXLg6Nab73rjR9c/9AdKqBbwVMHyrQ==",
       "requires": {
-        "@sentry/core": "7.119.1",
-        "@sentry/types": "7.119.1",
-        "@sentry/utils": "7.119.1",
+        "@sentry/core": "7.119.2",
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2",
         "localforage": "^1.8.1"
       }
     },
     "@sentry/replay": {
-      "version": "7.119.1",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.119.1.tgz",
-      "integrity": "sha512-4da+ruMEipuAZf35Ybt2StBdV1S+oJbSVccGpnl9w6RoeQoloT4ztR6ML3UcFDTXeTPT1FnHWDCyOfST0O7XMw==",
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.119.2.tgz",
+      "integrity": "sha512-nHDsBt0mlJXTWAHjzQdCzDbhV2fv8B62PPB5mu5SpI+G5h+ir3r5lR0lZZrMT8eurVowb/HnLXAs+XYVug3blg==",
       "requires": {
-        "@sentry-internal/tracing": "7.119.1",
-        "@sentry/core": "7.119.1",
-        "@sentry/types": "7.119.1",
-        "@sentry/utils": "7.119.1"
+        "@sentry-internal/tracing": "7.119.2",
+        "@sentry/core": "7.119.2",
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2"
       }
     },
     "@sentry/types": {
-      "version": "7.119.1",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.119.1.tgz",
-      "integrity": "sha512-4G2mcZNnYzK3pa2PuTq+M2GcwBRY/yy1rF+HfZU+LAPZr98nzq2X3+mJHNJoobeHRkvVh7YZMPi4ogXiIS5VNQ=="
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.119.2.tgz",
+      "integrity": "sha512-ydq1tWsdG7QW+yFaTp0gFaowMLNVikIqM70wxWNK+u98QzKnVY/3XTixxNLsUtnAB4Y+isAzFhrc6Vb5GFdFeg=="
     },
     "@sentry/utils": {
-      "version": "7.119.1",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.119.1.tgz",
-      "integrity": "sha512-ju/Cvyeu/vkfC5/XBV30UNet5kLEicZmXSyuLwZu95hEbL+foPdxN+re7pCI/eNqfe3B2vz7lvz5afLVOlQ2Hg==",
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.119.2.tgz",
+      "integrity": "sha512-TLdUCvcNgzKP0r9YD7tgCL1PEUp42TObISridsPJ5rhpVGQJvpr+Six0zIkfDUxerLYWZoK8QMm9KgFlPLNQzA==",
       "requires": {
-        "@sentry/types": "7.119.1"
+        "@sentry/types": "7.119.2"
       }
     },
     "@types/estree": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nextcloud_sentry",
-  "version": "8.9.9",
+  "version": "8.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,13 +6,13 @@
   "packages": {
     "": {
       "name": "nextcloud_sentry",
-      "version": "8.12.1",
+      "version": "8.12.2",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.4.0",
         "@nextcloud/initial-state": "^2.2.0",
         "@nextcloud/logger": "^3.0.2",
-        "@sentry/browser": "^7.119.2"
+        "@sentry/browser": "^7.120.0"
       },
       "devDependencies": {
         "webpack": "^5.96.1",
@@ -147,83 +147,83 @@
       }
     },
     "node_modules/@sentry-internal/feedback": {
-      "version": "7.119.2",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.119.2.tgz",
-      "integrity": "sha512-bnR1yJWVBZfXGx675nMXE8hCXsxluCBfIFy9GQT8PTN/urxpoS9cGz+5F7MA7Xe3Q06/7TT0Mz3fcDvjkqTu3Q==",
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.120.0.tgz",
+      "integrity": "sha512-+nU2PXMAyrYyK64PlfxXyRZ+LIl6IWAcdnBeX916WqOJy2WWmtdOrAX8muVwLVIXHzp1EMG1nEZgtpL/Vr2XKQ==",
       "dependencies": {
-        "@sentry/core": "7.119.2",
-        "@sentry/types": "7.119.2",
-        "@sentry/utils": "7.119.2"
+        "@sentry/core": "7.120.0",
+        "@sentry/types": "7.120.0",
+        "@sentry/utils": "7.120.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@sentry-internal/replay-canvas": {
-      "version": "7.119.2",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.119.2.tgz",
-      "integrity": "sha512-Lqo8IFyeKkdOrOGRqm9jCEqeBl8kINe5+c2VqULpkO/I6ql6ISwPSYnmG6yL8cCVIaT1893CLog/pS4FxCv8/Q==",
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.120.0.tgz",
+      "integrity": "sha512-ZEFZBP+Jxmy/8IY7IZDZVPqAJ6pPxAFo1lNTd8xfpbno3WAtHw0FLewLfjrFt0zfIgCk8EXj4PW355zRP3C2NQ==",
       "dependencies": {
-        "@sentry/core": "7.119.2",
-        "@sentry/replay": "7.119.2",
-        "@sentry/types": "7.119.2",
-        "@sentry/utils": "7.119.2"
+        "@sentry/core": "7.120.0",
+        "@sentry/replay": "7.120.0",
+        "@sentry/types": "7.120.0",
+        "@sentry/utils": "7.120.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@sentry-internal/tracing": {
-      "version": "7.119.2",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.119.2.tgz",
-      "integrity": "sha512-V2W+STWrafyGJhQv3ulMFXYDwWHiU6wHQAQBShsHVACiFaDrJ2kPRet38FKv4dMLlLlP2xN+ss2e5zv3tYlTiQ==",
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.120.0.tgz",
+      "integrity": "sha512-VymJoIGMV0PcTJyshka9uJ1sKpR7bHooqW5jTEr6g0dYAwB723fPXHjVW+7SETF7i5+yr2KMprYKreqRidKyKA==",
       "dependencies": {
-        "@sentry/core": "7.119.2",
-        "@sentry/types": "7.119.2",
-        "@sentry/utils": "7.119.2"
+        "@sentry/core": "7.120.0",
+        "@sentry/types": "7.120.0",
+        "@sentry/utils": "7.120.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "7.119.2",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.119.2.tgz",
-      "integrity": "sha512-Wb2RzCsJBTNCmS9KPmbVyV5GGzFXjFdUThAN9xlnN5GgemMBwdQjGu/tRYr8yJAVsRb0EOFH8IuJBNKKNnO49g==",
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.120.0.tgz",
+      "integrity": "sha512-2hRE3QPLBBX+qqZEHY2IbJv4YvfXY7m/bWmNjN15phyNK3oBcm2Pa8ZiKUYrk8u/4DCEGzNUlhOmFgaxwSfpNw==",
       "dependencies": {
-        "@sentry-internal/feedback": "7.119.2",
-        "@sentry-internal/replay-canvas": "7.119.2",
-        "@sentry-internal/tracing": "7.119.2",
-        "@sentry/core": "7.119.2",
-        "@sentry/integrations": "7.119.2",
-        "@sentry/replay": "7.119.2",
-        "@sentry/types": "7.119.2",
-        "@sentry/utils": "7.119.2"
+        "@sentry-internal/feedback": "7.120.0",
+        "@sentry-internal/replay-canvas": "7.120.0",
+        "@sentry-internal/tracing": "7.120.0",
+        "@sentry/core": "7.120.0",
+        "@sentry/integrations": "7.120.0",
+        "@sentry/replay": "7.120.0",
+        "@sentry/types": "7.120.0",
+        "@sentry/utils": "7.120.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/core": {
-      "version": "7.119.2",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.119.2.tgz",
-      "integrity": "sha512-hQr3d2yWq/2lMvoyBPOwXw1IHqTrCjOsU1vYKhAa6w9vGbJZFGhKGGE2KEi/92c3gqGn+gW/PC7cV6waCTDuVA==",
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.120.0.tgz",
+      "integrity": "sha512-uTc2sUQ0heZrMI31oFOHGxjKgw16MbV3C2mcT7qcrb6UmSGR9WqPOXZhnVVuzPWCnQ8B5IPPVdynK//J+9/m6g==",
       "dependencies": {
-        "@sentry/types": "7.119.2",
-        "@sentry/utils": "7.119.2"
+        "@sentry/types": "7.120.0",
+        "@sentry/utils": "7.120.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/integrations": {
-      "version": "7.119.2",
-      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.119.2.tgz",
-      "integrity": "sha512-dCuXKvbUE3gXVVa696SYMjlhSP6CxpMH/gl4Jk26naEB8Xjsn98z/hqEoXLg6Nab73rjR9c/9AdKqBbwVMHyrQ==",
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.120.0.tgz",
+      "integrity": "sha512-/Hs9MgSmG4JFNyeQkJ+MWh/fxO/U38Pz0VSH3hDrfyCjI8vH9Vz9inGEQXgB9Ke4eH8XnhsQ7xPnM27lWJts6g==",
       "dependencies": {
-        "@sentry/core": "7.119.2",
-        "@sentry/types": "7.119.2",
-        "@sentry/utils": "7.119.2",
+        "@sentry/core": "7.120.0",
+        "@sentry/types": "7.120.0",
+        "@sentry/utils": "7.120.0",
         "localforage": "^1.8.1"
       },
       "engines": {
@@ -231,33 +231,33 @@
       }
     },
     "node_modules/@sentry/replay": {
-      "version": "7.119.2",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.119.2.tgz",
-      "integrity": "sha512-nHDsBt0mlJXTWAHjzQdCzDbhV2fv8B62PPB5mu5SpI+G5h+ir3r5lR0lZZrMT8eurVowb/HnLXAs+XYVug3blg==",
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.120.0.tgz",
+      "integrity": "sha512-wV9fIYwNtMvFOHQB5eSm+kCorRXsX5+v1DxyTC8Lee1hfzcUQ2Wvqh75VktpXuM9TeZE8h7aQ4Wo4qCgTUdtvA==",
       "dependencies": {
-        "@sentry-internal/tracing": "7.119.2",
-        "@sentry/core": "7.119.2",
-        "@sentry/types": "7.119.2",
-        "@sentry/utils": "7.119.2"
+        "@sentry-internal/tracing": "7.120.0",
+        "@sentry/core": "7.120.0",
+        "@sentry/types": "7.120.0",
+        "@sentry/utils": "7.120.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@sentry/types": {
-      "version": "7.119.2",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.119.2.tgz",
-      "integrity": "sha512-ydq1tWsdG7QW+yFaTp0gFaowMLNVikIqM70wxWNK+u98QzKnVY/3XTixxNLsUtnAB4Y+isAzFhrc6Vb5GFdFeg==",
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.120.0.tgz",
+      "integrity": "sha512-3mvELhBQBo6EljcRrJzfpGJYHKIZuBXmqh0y8prh03SWE62pwRL614GIYtd4YOC6OP1gfPn8S8h9w3dD5bF5HA==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "7.119.2",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.119.2.tgz",
-      "integrity": "sha512-TLdUCvcNgzKP0r9YD7tgCL1PEUp42TObISridsPJ5rhpVGQJvpr+Six0zIkfDUxerLYWZoK8QMm9KgFlPLNQzA==",
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.120.0.tgz",
+      "integrity": "sha512-XZsPcBHoYu4+HYn14IOnhabUZgCF99Xn4IdWn8Hjs/c+VPtuAVDhRTsfPyPrpY3OcN8DgO5fZX4qcv/6kNbX1A==",
       "dependencies": {
-        "@sentry/types": "7.119.2"
+        "@sentry/types": "7.120.0"
       },
       "engines": {
         "node": ">=8"
@@ -1687,93 +1687,93 @@
       }
     },
     "@sentry-internal/feedback": {
-      "version": "7.119.2",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.119.2.tgz",
-      "integrity": "sha512-bnR1yJWVBZfXGx675nMXE8hCXsxluCBfIFy9GQT8PTN/urxpoS9cGz+5F7MA7Xe3Q06/7TT0Mz3fcDvjkqTu3Q==",
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.120.0.tgz",
+      "integrity": "sha512-+nU2PXMAyrYyK64PlfxXyRZ+LIl6IWAcdnBeX916WqOJy2WWmtdOrAX8muVwLVIXHzp1EMG1nEZgtpL/Vr2XKQ==",
       "requires": {
-        "@sentry/core": "7.119.2",
-        "@sentry/types": "7.119.2",
-        "@sentry/utils": "7.119.2"
+        "@sentry/core": "7.120.0",
+        "@sentry/types": "7.120.0",
+        "@sentry/utils": "7.120.0"
       }
     },
     "@sentry-internal/replay-canvas": {
-      "version": "7.119.2",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.119.2.tgz",
-      "integrity": "sha512-Lqo8IFyeKkdOrOGRqm9jCEqeBl8kINe5+c2VqULpkO/I6ql6ISwPSYnmG6yL8cCVIaT1893CLog/pS4FxCv8/Q==",
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.120.0.tgz",
+      "integrity": "sha512-ZEFZBP+Jxmy/8IY7IZDZVPqAJ6pPxAFo1lNTd8xfpbno3WAtHw0FLewLfjrFt0zfIgCk8EXj4PW355zRP3C2NQ==",
       "requires": {
-        "@sentry/core": "7.119.2",
-        "@sentry/replay": "7.119.2",
-        "@sentry/types": "7.119.2",
-        "@sentry/utils": "7.119.2"
+        "@sentry/core": "7.120.0",
+        "@sentry/replay": "7.120.0",
+        "@sentry/types": "7.120.0",
+        "@sentry/utils": "7.120.0"
       }
     },
     "@sentry-internal/tracing": {
-      "version": "7.119.2",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.119.2.tgz",
-      "integrity": "sha512-V2W+STWrafyGJhQv3ulMFXYDwWHiU6wHQAQBShsHVACiFaDrJ2kPRet38FKv4dMLlLlP2xN+ss2e5zv3tYlTiQ==",
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.120.0.tgz",
+      "integrity": "sha512-VymJoIGMV0PcTJyshka9uJ1sKpR7bHooqW5jTEr6g0dYAwB723fPXHjVW+7SETF7i5+yr2KMprYKreqRidKyKA==",
       "requires": {
-        "@sentry/core": "7.119.2",
-        "@sentry/types": "7.119.2",
-        "@sentry/utils": "7.119.2"
+        "@sentry/core": "7.120.0",
+        "@sentry/types": "7.120.0",
+        "@sentry/utils": "7.120.0"
       }
     },
     "@sentry/browser": {
-      "version": "7.119.2",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.119.2.tgz",
-      "integrity": "sha512-Wb2RzCsJBTNCmS9KPmbVyV5GGzFXjFdUThAN9xlnN5GgemMBwdQjGu/tRYr8yJAVsRb0EOFH8IuJBNKKNnO49g==",
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.120.0.tgz",
+      "integrity": "sha512-2hRE3QPLBBX+qqZEHY2IbJv4YvfXY7m/bWmNjN15phyNK3oBcm2Pa8ZiKUYrk8u/4DCEGzNUlhOmFgaxwSfpNw==",
       "requires": {
-        "@sentry-internal/feedback": "7.119.2",
-        "@sentry-internal/replay-canvas": "7.119.2",
-        "@sentry-internal/tracing": "7.119.2",
-        "@sentry/core": "7.119.2",
-        "@sentry/integrations": "7.119.2",
-        "@sentry/replay": "7.119.2",
-        "@sentry/types": "7.119.2",
-        "@sentry/utils": "7.119.2"
+        "@sentry-internal/feedback": "7.120.0",
+        "@sentry-internal/replay-canvas": "7.120.0",
+        "@sentry-internal/tracing": "7.120.0",
+        "@sentry/core": "7.120.0",
+        "@sentry/integrations": "7.120.0",
+        "@sentry/replay": "7.120.0",
+        "@sentry/types": "7.120.0",
+        "@sentry/utils": "7.120.0"
       }
     },
     "@sentry/core": {
-      "version": "7.119.2",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.119.2.tgz",
-      "integrity": "sha512-hQr3d2yWq/2lMvoyBPOwXw1IHqTrCjOsU1vYKhAa6w9vGbJZFGhKGGE2KEi/92c3gqGn+gW/PC7cV6waCTDuVA==",
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.120.0.tgz",
+      "integrity": "sha512-uTc2sUQ0heZrMI31oFOHGxjKgw16MbV3C2mcT7qcrb6UmSGR9WqPOXZhnVVuzPWCnQ8B5IPPVdynK//J+9/m6g==",
       "requires": {
-        "@sentry/types": "7.119.2",
-        "@sentry/utils": "7.119.2"
+        "@sentry/types": "7.120.0",
+        "@sentry/utils": "7.120.0"
       }
     },
     "@sentry/integrations": {
-      "version": "7.119.2",
-      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.119.2.tgz",
-      "integrity": "sha512-dCuXKvbUE3gXVVa696SYMjlhSP6CxpMH/gl4Jk26naEB8Xjsn98z/hqEoXLg6Nab73rjR9c/9AdKqBbwVMHyrQ==",
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.120.0.tgz",
+      "integrity": "sha512-/Hs9MgSmG4JFNyeQkJ+MWh/fxO/U38Pz0VSH3hDrfyCjI8vH9Vz9inGEQXgB9Ke4eH8XnhsQ7xPnM27lWJts6g==",
       "requires": {
-        "@sentry/core": "7.119.2",
-        "@sentry/types": "7.119.2",
-        "@sentry/utils": "7.119.2",
+        "@sentry/core": "7.120.0",
+        "@sentry/types": "7.120.0",
+        "@sentry/utils": "7.120.0",
         "localforage": "^1.8.1"
       }
     },
     "@sentry/replay": {
-      "version": "7.119.2",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.119.2.tgz",
-      "integrity": "sha512-nHDsBt0mlJXTWAHjzQdCzDbhV2fv8B62PPB5mu5SpI+G5h+ir3r5lR0lZZrMT8eurVowb/HnLXAs+XYVug3blg==",
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.120.0.tgz",
+      "integrity": "sha512-wV9fIYwNtMvFOHQB5eSm+kCorRXsX5+v1DxyTC8Lee1hfzcUQ2Wvqh75VktpXuM9TeZE8h7aQ4Wo4qCgTUdtvA==",
       "requires": {
-        "@sentry-internal/tracing": "7.119.2",
-        "@sentry/core": "7.119.2",
-        "@sentry/types": "7.119.2",
-        "@sentry/utils": "7.119.2"
+        "@sentry-internal/tracing": "7.120.0",
+        "@sentry/core": "7.120.0",
+        "@sentry/types": "7.120.0",
+        "@sentry/utils": "7.120.0"
       }
     },
     "@sentry/types": {
-      "version": "7.119.2",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.119.2.tgz",
-      "integrity": "sha512-ydq1tWsdG7QW+yFaTp0gFaowMLNVikIqM70wxWNK+u98QzKnVY/3XTixxNLsUtnAB4Y+isAzFhrc6Vb5GFdFeg=="
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.120.0.tgz",
+      "integrity": "sha512-3mvELhBQBo6EljcRrJzfpGJYHKIZuBXmqh0y8prh03SWE62pwRL614GIYtd4YOC6OP1gfPn8S8h9w3dD5bF5HA=="
     },
     "@sentry/utils": {
-      "version": "7.119.2",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.119.2.tgz",
-      "integrity": "sha512-TLdUCvcNgzKP0r9YD7tgCL1PEUp42TObISridsPJ5rhpVGQJvpr+Six0zIkfDUxerLYWZoK8QMm9KgFlPLNQzA==",
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.120.0.tgz",
+      "integrity": "sha512-XZsPcBHoYu4+HYn14IOnhabUZgCF99Xn4IdWn8Hjs/c+VPtuAVDhRTsfPyPrpY3OcN8DgO5fZX4qcv/6kNbX1A==",
       "requires": {
-        "@sentry/types": "7.119.2"
+        "@sentry/types": "7.120.0"
       }
     },
     "@types/eslint": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,12 +6,12 @@
   "packages": {
     "": {
       "name": "nextcloud_sentry",
-      "version": "8.9.9",
+      "version": "8.10.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.2.1",
         "@nextcloud/initial-state": "^2.2.0",
-        "@nextcloud/logger": "^2.7.0",
+        "@nextcloud/logger": "^3.0.2",
         "@sentry/browser": "^7.118.0"
       },
       "devDependencies": {
@@ -88,27 +88,28 @@
       }
     },
     "node_modules/@nextcloud/auth": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-2.2.1.tgz",
-      "integrity": "sha512-zYtgrg9NMZfN8kmL5JPCsh5jDhpTCEslhnZWMvbhTiQ7hrOnji/67ok6VMK0CTJ1a92Vr67Ow72lW7YRX69zEA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-2.3.0.tgz",
+      "integrity": "sha512-PCkRJbML9sXvBENY43vTIERIZJFk2azu08IK6zYOnOZ7cFkD1QlFJtdTCZTImQLg01IXhIm0j0ExEdatHoqz7g==",
       "dependencies": {
-        "@nextcloud/event-bus": "^3.1.0"
+        "@nextcloud/event-bus": "^3.2.0"
       },
       "engines": {
         "node": "^20.0.0",
-        "npm": "^9.0.0"
+        "npm": "^10.0.0"
       }
     },
     "node_modules/@nextcloud/event-bus": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-3.1.0.tgz",
-      "integrity": "sha512-purXQsXbhbmpcDsbDuR0i7vwUgOsqnIUa7QAD3lV/UZUkUT94SmxBM5LgQ8iV8TQBWWleEwQHy5kYfHeTGF9wg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-3.3.1.tgz",
+      "integrity": "sha512-VBYJspOVk5aZopgZwCUoMKFqcTLCNel2TLvtu0HMPV2gR5ZLPiPAKbkyKkYTh+Sd5QB1gR6l3STTv1gyal0soQ==",
       "dependencies": {
-        "semver": "^7.5.1"
+        "@types/node": "^20.12.12",
+        "semver": "^7.6.2"
       },
       "engines": {
-        "node": "^16.0.0",
-        "npm": "^7.0.0 || ^8.0.0"
+        "node": "^20.0.0",
+        "npm": "^10.0.0"
       }
     },
     "node_modules/@nextcloud/initial-state": {
@@ -121,16 +122,15 @@
       }
     },
     "node_modules/@nextcloud/logger": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/logger/-/logger-2.7.0.tgz",
-      "integrity": "sha512-DSJg9H1jT2zfr7uoP4tL5hKncyY+LOuxJzLauj0M/f6gnpoXU5WG1Zw8EFPOrRWjkC0ZE+NCqrMnITgdRRpXJQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@nextcloud/logger/-/logger-3.0.2.tgz",
+      "integrity": "sha512-wByt0R0/6QC44RBpaJr1MWghjjOxk/pRbACHo/ZWWKht1qYbJRHB4GtEi+35KEIHY07ZpqxiDk6dIRuN7sXYWQ==",
       "dependencies": {
-        "@nextcloud/auth": "^2.0.0",
-        "core-js": "^3.6.4"
+        "@nextcloud/auth": "^2.3.0"
       },
       "engines": {
         "node": "^20.0.0",
-        "npm": "^9.0.0"
+        "npm": "^10.0.0"
       }
     },
     "node_modules/@sentry-internal/feedback": {
@@ -283,10 +283,12 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.0.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.13.tgz",
-      "integrity": "sha512-rouEWBImiRaSJsVA+ITTFM6ZxibuAlTuNOCyxVbwreu6k6+ujs7DfnU9o+PShFhET78pMBl3eH+AGSI5eOTkPA==",
-      "dev": true
+      "version": "20.14.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.11.tgz",
+      "integrity": "sha512-kprQpL8MMeszbz6ojB5/tU8PLN4kesnN8Gjzw349rDlNgsSzg90lAVj3llK99Dh7JON+t9AuscPPFW6mPbTnSA==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.12.1",
@@ -631,17 +633,6 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
-    },
-    "node_modules/core-js": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
-      "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw==",
-      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
-      "hasInstallScript": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -996,17 +987,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -1231,12 +1211,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -1383,6 +1360,11 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
       "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
       "dev": true
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/update-browserslist-db": {
       "version": "1.0.13",
@@ -1580,11 +1562,6 @@
       "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
       "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
       "dev": true
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   },
   "dependencies": {
@@ -1644,19 +1621,20 @@
       }
     },
     "@nextcloud/auth": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-2.2.1.tgz",
-      "integrity": "sha512-zYtgrg9NMZfN8kmL5JPCsh5jDhpTCEslhnZWMvbhTiQ7hrOnji/67ok6VMK0CTJ1a92Vr67Ow72lW7YRX69zEA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-2.3.0.tgz",
+      "integrity": "sha512-PCkRJbML9sXvBENY43vTIERIZJFk2azu08IK6zYOnOZ7cFkD1QlFJtdTCZTImQLg01IXhIm0j0ExEdatHoqz7g==",
       "requires": {
-        "@nextcloud/event-bus": "^3.1.0"
+        "@nextcloud/event-bus": "^3.2.0"
       }
     },
     "@nextcloud/event-bus": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-3.1.0.tgz",
-      "integrity": "sha512-purXQsXbhbmpcDsbDuR0i7vwUgOsqnIUa7QAD3lV/UZUkUT94SmxBM5LgQ8iV8TQBWWleEwQHy5kYfHeTGF9wg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-3.3.1.tgz",
+      "integrity": "sha512-VBYJspOVk5aZopgZwCUoMKFqcTLCNel2TLvtu0HMPV2gR5ZLPiPAKbkyKkYTh+Sd5QB1gR6l3STTv1gyal0soQ==",
       "requires": {
-        "semver": "^7.5.1"
+        "@types/node": "^20.12.12",
+        "semver": "^7.6.2"
       }
     },
     "@nextcloud/initial-state": {
@@ -1665,12 +1643,11 @@
       "integrity": "sha512-cDW98L5KGGgpS8pzd+05304/p80cyu8U2xSDQGa+kGPTpUFmCbv2qnO5WrwwGTauyjYijCal2bmw82VddSH+Pg=="
     },
     "@nextcloud/logger": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/logger/-/logger-2.7.0.tgz",
-      "integrity": "sha512-DSJg9H1jT2zfr7uoP4tL5hKncyY+LOuxJzLauj0M/f6gnpoXU5WG1Zw8EFPOrRWjkC0ZE+NCqrMnITgdRRpXJQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@nextcloud/logger/-/logger-3.0.2.tgz",
+      "integrity": "sha512-wByt0R0/6QC44RBpaJr1MWghjjOxk/pRbACHo/ZWWKht1qYbJRHB4GtEi+35KEIHY07ZpqxiDk6dIRuN7sXYWQ==",
       "requires": {
-        "@nextcloud/auth": "^2.0.0",
-        "core-js": "^3.6.4"
+        "@nextcloud/auth": "^2.3.0"
       }
     },
     "@sentry-internal/feedback": {
@@ -1796,10 +1773,12 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.0.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.13.tgz",
-      "integrity": "sha512-rouEWBImiRaSJsVA+ITTFM6ZxibuAlTuNOCyxVbwreu6k6+ujs7DfnU9o+PShFhET78pMBl3eH+AGSI5eOTkPA==",
-      "dev": true
+      "version": "20.14.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.11.tgz",
+      "integrity": "sha512-kprQpL8MMeszbz6ojB5/tU8PLN4kesnN8Gjzw349rDlNgsSzg90lAVj3llK99Dh7JON+t9AuscPPFW6mPbTnSA==",
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
     },
     "@webassemblyjs/ast": {
       "version": "1.12.1",
@@ -2067,11 +2046,6 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
-    },
-    "core-js": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
-      "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw=="
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -2346,14 +2320,6 @@
         "p-locate": "^4.1.0"
       }
     },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "requires": {
-        "yallist": "^4.0.0"
-      }
-    },
     "merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -2512,12 +2478,9 @@
       }
     },
     "semver": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
-      "requires": {
-        "lru-cache": "^6.0.0"
-      }
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A=="
     },
     "serialize-javascript": {
       "version": "6.0.1",
@@ -2610,6 +2573,11 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
       "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
       "dev": true
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "update-browserslist-db": {
       "version": "1.0.13",
@@ -2732,11 +2700,6 @@
       "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
       "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
       "dev": true
-    },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextcloud_sentry",
-  "version": "8.12.0",
+  "version": "8.12.1",
   "description": "Sentry integration for Nextcloud",
   "main": "init.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@sentry/browser": "^7.119.2"
   },
   "devDependencies": {
-    "webpack": "^5.93.0",
+    "webpack": "^5.95.0",
     "webpack-cli": "^5.1.4",
     "webpack-merge": "^6.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@sentry/browser": "^7.119.2"
   },
   "devDependencies": {
-    "webpack": "^5.95.0",
+    "webpack": "^5.96.1",
     "webpack-cli": "^5.1.4",
     "webpack-merge": "^6.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "webpack": "^5.93.0",
     "webpack-cli": "^5.1.4",
-    "webpack-merge": "^5.10.0"
+    "webpack-merge": "^6.0.1"
   },
   "scripts": {
     "build": "webpack --config src/webpack.prod.config.js",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@nextcloud/auth": "^2.4.0",
     "@nextcloud/initial-state": "^2.2.0",
     "@nextcloud/logger": "^3.0.2",
-    "@sentry/browser": "^7.119.2"
+    "@sentry/browser": "^7.120.0"
   },
   "devDependencies": {
     "webpack": "^5.96.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextcloud_sentry",
-  "version": "8.12.2",
+  "version": "8.12.3",
   "description": "Sentry integration for Nextcloud",
   "main": "init.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@nextcloud/auth": "^2.4.0",
     "@nextcloud/initial-state": "^2.2.0",
     "@nextcloud/logger": "^3.0.2",
-    "@sentry/browser": "^7.118.0"
+    "@sentry/browser": "^7.119.2"
   },
   "devDependencies": {
     "webpack": "^5.93.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@nextcloud/auth": "^2.2.1",
     "@nextcloud/initial-state": "^2.1.0",
     "@nextcloud/logger": "^2.7.0",
-    "@sentry/browser": "^7.108.0"
+    "@sentry/browser": "^7.118.0"
   },
   "devDependencies": {
     "webpack": "^5.91.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextcloud_sentry",
-  "version": "8.12.1",
+  "version": "8.12.2",
   "description": "Sentry integration for Nextcloud",
   "main": "init.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@nextcloud/auth": "^2.2.1",
     "@nextcloud/initial-state": "^2.2.0",
-    "@nextcloud/logger": "^2.7.0",
+    "@nextcloud/logger": "^3.0.2",
     "@sentry/browser": "^7.118.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@nextcloud/auth": "^2.2.1",
-    "@nextcloud/initial-state": "^2.1.0",
+    "@nextcloud/initial-state": "^2.2.0",
     "@nextcloud/logger": "^2.7.0",
     "@sentry/browser": "^7.108.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextcloud_sentry",
-  "version": "8.11.0",
+  "version": "8.12.0",
   "description": "Sentry integration for Nextcloud",
   "main": "init.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lib": "lib"
   },
   "dependencies": {
-    "@nextcloud/auth": "^2.2.1",
+    "@nextcloud/auth": "^2.3.0",
     "@nextcloud/initial-state": "^2.2.0",
     "@nextcloud/logger": "^2.7.0",
     "@sentry/browser": "^7.118.0"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lib": "lib"
   },
   "dependencies": {
-    "@nextcloud/auth": "^2.3.0",
+    "@nextcloud/auth": "^2.4.0",
     "@nextcloud/initial-state": "^2.2.0",
     "@nextcloud/logger": "^3.0.2",
     "@sentry/browser": "^7.118.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextcloud_sentry",
-  "version": "8.10.0",
+  "version": "8.10.1",
   "description": "Sentry integration for Nextcloud",
   "main": "init.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@sentry/browser": "^7.108.0"
   },
   "devDependencies": {
-    "webpack": "^5.91.0",
+    "webpack": "^5.93.0",
     "webpack-cli": "^5.1.4",
     "webpack-merge": "^5.10.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextcloud_sentry",
-  "version": "8.10.1",
+  "version": "8.11.0",
   "description": "Sentry integration for Nextcloud",
   "main": "init.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextcloud_sentry",
-  "version": "8.9.9",
+  "version": "8.10.0",
   "description": "Sentry integration for Nextcloud",
   "main": "init.js",
   "directories": {

--- a/tests/Integration/ReportToSentryIoTest.php
+++ b/tests/Integration/ReportToSentryIoTest.php
@@ -28,14 +28,13 @@ namespace OCA\sentry\tests\Integration;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
 use Exception;
-use OCP\ILogger;
+use function OCP\Log\logger;
 
 class ReportToSentryIoTest extends TestCase {
 
 	public function testSendException() {
-		/** @var ILogger $logger */
-		$logger = \OC::$server->query(ILogger::class);
-		$logger->logException(new Exception('Test is a Sentry CI test'));
+		$logger = logger('sentry');
+		$logger->critical('Test is a Sentry CI test', ['exception' => new Exception('Test is a Sentry CI test')]);
 		$this->addToAssertionCount(1);
 	}
 


### PR DESCRIPTION
- **ci: Test Nextcloud server master with PHP8.2**
- **feat(deps): Support Nextcloud 30, drop 24-27**
- **chore(deps): update dependency psalm/phar to ^5.25.0**
- **fix(deps): update dependency @nextcloud/initial-state to ^2.2.0**
- **fix(deps): update dependency @sentry/browser to ^7.118.0**
- **chore(deps): update dependency webpack to ^5.93.0**
- **chore(release): v8.10.0 [skip ci]**
- **fix(deps): update dependency @nextcloud/auth to ^2.3.0**
- **fix(deps): update dependency @nextcloud/logger to v3**
- **chore(deps): update dependency webpack-merge to v6**
- **chore(release): v8.10.1 [skip ci]**
- **feat(environment): Add support for environment config parameter**
- **chore(release): v8.11.0 [skip ci]**
- **feat(deps): Add Nextcloud 31 support**
- **fix: Do not ship psr/log**
- **test: Use LoggerInterface instead of ILogger**
- **fix(deps): update dependency nyholm/psr7 to ^1.8.2 (#686)**
- **chore(deps): update dependency psalm/phar to ^5.26.1 (#685)**
- **fix(deps): update dependency @nextcloud/auth to ^2.4.0**
- **fix(deps): update dependency @sentry/browser to v7.119.1 [security] (#687)**
- **chore(release): v8.12.0 [skip ci]**
- **chore(deps): update dependency webpack to v5.94.0 [security] (#684)**
- **fix(deps): update dependency @sentry/browser to ^7.119.2 (#691)**
- **chore(deps): update dependency webpack to ^5.95.0 (#692)**
- **chore(release): v8.12.1 [skip ci]**
- **fix(deps): update dependency php-http/curl-client to ^2.3.3 (#694)**
- **chore(deps): update dependency webpack to ^5.96.1 (#695)**
- **chore(release): v8.12.2 [skip ci]**
- **fix(deps): update dependency @sentry/browser to ^7.120.0 (#696)**
- **chore(release): v8.12.3 [skip ci]**
- **chore: Switch ILogger to LoggerInterface**
